### PR TITLE
Configure Tagger extension

### DIFF
--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -6,6 +6,7 @@ Awestruct::Extensions::Pipeline.new do
   extension Awestruct::Extensions::Indexifier.new
   extension Awestruct::Extensions::Sitemap.new
   extension Awestruct::Extensions::Paginator.new( :posts, '/news/index', :per_page => 5 )
+  extension Awestruct::Extensions::Tagger.new( :posts, '/news/index', '/news/tags', :per_page=>10 )
   extension Awestruct::Extensions::Atomizer.new(:posts, '/news.atom')
   extension Awestruct::Extensions::FAQ.new( '_faq', :faq )
   extension Awestruct::Extensions::Disqus.new

--- a/_layouts/news.html.haml
+++ b/_layouts/news.html.haml
@@ -8,8 +8,27 @@ layout: base
       %i.fa.fa-rss
   %div.news-date.news-boxed
     #{page.date.year}-#{page.date.month}-#{page.date.day}
-  %div.news-author.news-boxed
+    - if (page.tags.length > 0)
+      &nbsp;
+      %span.tags
+        %i.fa.fa-tags
+        - for tag in page.tags
+          - link = "/news/tags/"
+          - link << tag.to_s
+          %a{:href=>link}<
+            #{tag}
+          - if tag != page.tags.last
+            =", "
+    &nbsp;
+    %i.fa.fa-pencil
     #{page.author}
+  - if page.tags
+    %p.tags
+    - for tag in page.tags
+      - link = "/news/tags/"
+      - link << tag.to_s
+      %a{:href=>link}
+        #{tag}
   %p
   .content
     ~ content

--- a/index.html.haml
+++ b/index.html.haml
@@ -84,6 +84,17 @@ desc: Weld - CDI Reference Implementation
             - if (post.content.length > 0)
               %div.news-date.news-boxed
                 #{post.date.year}-#{post.date.month}-#{post.date.day}
+                - if (post.tags.length > 0)
+                  &nbsp;
+                  %span.tags
+                    %i.fa.fa-tags
+                    - for tag in post.tags
+                      - link = "/news/tags/"
+                      - link << tag.to_s
+                      %a{:href=>link}<
+                        #{tag}
+                      - if tag != post.tags.last
+                        =", "
               %p
                 = post.excerpt || summarize(html_to_text(post.content), 20)
                 %a{:href=>post.url} more

--- a/news/2014-12-10-an-update-on-weld-3.asciidoc
+++ b/news/2014-12-10-an-update-on-weld-3.asciidoc
@@ -4,6 +4,7 @@ title: An update on Weld 3
 author: Jozef Hartinger
 priority: 1
 change_frequency: weekly
+tags: [cdi2]
 ---
 
 Today we are releasing the third Alpha release of Weld 3. These Alpha releases serve

--- a/news/2015-02-05-weld-300Alpha4.asciidoc
+++ b/news/2015-02-05-weld-300Alpha4.asciidoc
@@ -4,6 +4,7 @@ title: Weld 3.0.0.Alpha4
 author: Jozef Hartinger
 priority: 1
 change_frequency: weekly
+tags: [release, cdi2]
 ---
 
 Here we are again with the next Alpha release of Weld 3.

--- a/news/2015-02-25-weld-300Alpha5.asciidoc
+++ b/news/2015-02-25-weld-300Alpha5.asciidoc
@@ -4,6 +4,7 @@ title: Weld 3.0.0.Alpha5
 author: Jozef Hartinger
 priority: 1
 change_frequency: weekly
+tags: [release, cdi2]
 ---
 
 Weld 3.0.0.Alpha5, the latest release in the series of CDI 2.0 prototypes, has been released.

--- a/news/2015-04-21-weld-300Alpha8.asciidoc
+++ b/news/2015-04-21-weld-300Alpha8.asciidoc
@@ -4,6 +4,7 @@ title: Weld 3.0.0.Alpha8
 author: Jozef Hartinger
 priority: 1
 change_frequency: weekly
+tags: [release, cdi2]
 ---
 
 Weld 3.0.0.Alpha8 has been released.

--- a/news/2015-08-05-weld-300Alpha12.asciidoc
+++ b/news/2015-08-05-weld-300Alpha12.asciidoc
@@ -4,6 +4,7 @@ title: Weld 3.0.0.Alpha12 - CDI 2.0 EDR1 Reference Implementation!
 author: Martin Kouba
 priority: 1
 change_frequency: weekly
+tags: [release, cdi2]
 ---
 
 Weld 3.0.0.Alpha12 has been released. Compared to previous alpha releases this is an important milestone - it's a reference implementation of link:http://docs.jboss.org/cdi/spec/2.0.EDR1/cdi-spec.html[CDI 2.0 Early Draft] (EDR1). You can read more about CDI 2.0 EDR1 on the official blog: link:http://www.cdi-spec.org/news/2015/07/03/CDI-2_0-EDR1-released/[CDI 2.0 Early Draft Review 1 released].

--- a/news/2015-09-08-weld-team-changes.asciidoc
+++ b/news/2015-09-08-weld-team-changes.asciidoc
@@ -4,6 +4,7 @@ title: Weld team changes
 author: Jozef Hartinger
 priority: 1
 change_frequency: weekly
+tags: [team]
 ---
 
 I am pleased to announce a couple of changes coming to the Weld team:

--- a/news/2015-09-15-jdk-8u60-problem.asciidoc
+++ b/news/2015-09-15-jdk-8u60-problem.asciidoc
@@ -4,6 +4,7 @@ title: JDK 8u60 reveals a problem in Weld
 author: Martin Kouba
 priority: 1
 change_frequency: weekly
+tags: [bug, jdk]
 ---
 
 Recently released *JDK 8u60* has revealed a problem in Weld where not all synthetic members were ignored correctly.

--- a/news/2015-09-18-weld-230Final.asciidoc
+++ b/news/2015-09-18-weld-230Final.asciidoc
@@ -4,6 +4,7 @@ title: Weld 2.3.0.Final released!
 author: Martin Kouba
 priority: 1
 change_frequency: weekly
+tags: [release]
 ---
 
 Weld 2.3.0.Final has been just released! From now on, 2.3 is the current stable version of Weld and 2.2 is not actively developed anymore - i.e. no new features are added, only bugs will be fixed. Weld 2.3 will remain a *CDI 1.2* implementation. We are incrementing the minor version due to several new features added. Weld 2.3 is also included in link:http://wildfly.org/[WildFly 10] application server.

--- a/news/2015-10-27-weld-231Final.asciidoc
+++ b/news/2015-10-27-weld-231Final.asciidoc
@@ -4,6 +4,7 @@ title: Weld 2.3.1.Final arrives...
 author: Martin Kouba
 priority: 1
 change_frequency: weekly
+tags: [release]
 ---
 
 Weld 2.3.1.Final has been released! The delivery: a few killed bugs, couple of Weld SE enhancements and several Weld Probe improvements.

--- a/news/2015-11-10-weld-probe-jmx.asciidoc
+++ b/news/2015-11-10-weld-probe-jmx.asciidoc
@@ -4,6 +4,7 @@ title: Weld development mode and JMX support
 author: Martin Kouba
 priority: 1
 change_frequency: weekly
+tags: [probe, jmx]
 ---
 
 Weld comes with a special mode for application development.

--- a/news/2015-11-25-arq-container-se-CR1.asciidoc
+++ b/news/2015-11-25-arq-container-se-CR1.asciidoc
@@ -4,6 +4,7 @@ title: Arquillian container SE 1.0.0.CR1 released!
 author: Tomas Remes
 priority: 1
 change_frequency: weekly
+tags: [arquillian, testing]
 ---
 
 We are pleased to announce a new release of Arquillian container SE.

--- a/news/2015-12-04-weld-300Alpha14.asciidoc
+++ b/news/2015-12-04-weld-300Alpha14.asciidoc
@@ -5,6 +5,7 @@ author: Martin Kouba
 priority: 1
 change_frequency: weekly
 desc: Weld 3.0.0.Alpha14 released.
+tags: [release, cdi2]
 ---
 
 Weld 3.0.0.Alpha14 the penultimate Weld version for this year has been released into the wild.

--- a/news/2015-12-10-weld-232Final.asciidoc
+++ b/news/2015-12-10-weld-232Final.asciidoc
@@ -5,6 +5,7 @@ author: Martin Kouba
 priority: 1
 change_frequency: weekly
 desc: Weld 2.3.2.Final released.
+tags: [release]
 ---
 
 Weld 2.3.2.Final the last version for this year has been released! It is a bug-fixing release with 15 issues resolved. See also https://issues.jboss.org/projects/WELD/versions/12328625[the release details]. Thanks to everyone involved in this release!

--- a/news/2016-02-04-weld-300Alpha15.asciidoc
+++ b/news/2016-02-04-weld-300Alpha15.asciidoc
@@ -6,6 +6,7 @@ priority: 1
 change_frequency: weekly
 excerpt: The next experimental Weld version has been released.
 desc: Weld 3.0.0.Alpha15 released. ExperimentalAfterBeanDiscovery event has been enhanced.
+tags: [release, cdi2]
 ---
 
 Weld 3.0.0.Alpha15 the next experimental Weld version has been released.

--- a/news/2016-02-08-weld-se-synth-lifecycle-events.asciidoc
+++ b/news/2016-02-08-weld-se-synth-lifecycle-events.asciidoc
@@ -6,6 +6,7 @@ priority: 1
 change_frequency: weekly
 excerpt: A new experimental feature of Weld SE planned for 3.0.0.Alpha16.
 desc: Weld SE 3.x introducing synthetic lifecycle event observer.
+tags: [api, draft]
 ---
 
 Last week Weld 3.0.0.Alpha15 was released and so it's time to reveal the features that should go into the next experimental release.

--- a/news/2016-02-12-weld-233Final.asciidoc
+++ b/news/2016-02-12-weld-233Final.asciidoc
@@ -6,6 +6,7 @@ priority: 1
 change_frequency: weekly
 excerpt: The next bug-fix release for the stable 2.3 branch (CDI 1.2 implementation) has been released.
 desc: Weld 2.3.3.Final released
+tags: [release]
 ---
 :linkattrs:
 

--- a/news/2016-04-11-weld-meets-vertx.asciidoc
+++ b/news/2016-04-11-weld-meets-vertx.asciidoc
@@ -5,6 +5,7 @@ author: Martin Kouba
 priority: 1
 change_frequency: weekly
 desc: Weld meets Vert.x
+tags: [vertx, integration]
 ---
 :linkattrs:
 

--- a/news/2016-04-22-weld-234Final.asciidoc
+++ b/news/2016-04-22-weld-234Final.asciidoc
@@ -6,6 +6,7 @@ priority: 1
 change_frequency: weekly
 excerpt: The next version of the stable 2.3 branch (CDI 1.2, WildFly 10) has been released.
 desc: Weld 2.3.4.Final released
+tags: [release]
 ---
 :linkattrs:
 

--- a/news/2016-04-28-weld-300Alpha16.asciidoc
+++ b/news/2016-04-28-weld-300Alpha16.asciidoc
@@ -6,6 +6,7 @@ priority: 1
 change_frequency: weekly
 excerpt: Start playing with metadata configurators included in the next experimental version of Weld (aligned with CDI 2.0.Alpha4).
 desc: Weld 3.0.0.Alpha16 released
+tags: [release, cdi2]
 ---
 :linkattrs:
 

--- a/news/2016-05-18-enhanced-instance.asciidoc
+++ b/news/2016-05-18-enhanced-instance.asciidoc
@@ -6,6 +6,7 @@ priority: 1
 change_frequency: weekly
 excerpt: Weld team is considering adding an enhanced version of javax.enterprise.inject.Instance to the Weld API. Explore the possibilities...
 desc: Experiments with enhanced version of javax.enterprise.inject.Instance
+tags: [api, draft]
 ---
 :linkattrs:
 

--- a/news/2016-06-21-update-on-weld-vertx.asciidoc
+++ b/news/2016-06-21-update-on-weld-vertx.asciidoc
@@ -6,6 +6,7 @@ priority: 1
 change_frequency: weekly
 excerpt: Weld team has just released the first version of weld-vertx. Check the new features and explore the possibilities.
 desc: Weld team has just released the first version of weld-vertx. Check the new features and explore the possibilities.
+tags: [vertx, integration]
 ---
 :linkattrs:
 

--- a/news/index.html.haml
+++ b/news/index.html.haml
@@ -18,7 +18,19 @@ desc: Latest news about Weld.
     - if (post.content.length > 0)
       %div.news-date.news-boxed
         #{post.date.year}-#{post.date.month}-#{post.date.day}
-      %div.news-author.news-boxed
+        - if (post.tags.length > 0)
+          &nbsp;
+          %span.tags
+            %i.fa.fa-tags
+            - for tag in post.tags
+              - link = "/news/tags/"
+              - link << tag.to_s
+              %a{:href=>link}<
+                #{tag}
+              - if tag != post.tags.last
+                =", "
+        &nbsp;
+        %i.fa.fa-pencil
         #{post.author}
     %p
     .content

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -275,11 +275,7 @@ div.search-results ol li p.search-desc {
 }
 
 div.news-date {
-    background-color: #82939d;
-}
-
-div.news-author {
-    background-color: #86b4dc;
+    background-color: #4a5860;
 }
 
 div.news-boxed {
@@ -321,4 +317,8 @@ div.admonitionblock .icon .title {
     color: #404040;
     border-right: 1px solid silver;
     padding: 10px;
+}
+
+span.tags a {
+    color: #e5eaec;
 }


### PR DESCRIPTION
NOTE: It seems there is a bug somewhere in awestruct (in development
mode). Any modification which triggers a page rebuild corrupts Tagger
metadata. As a result no tags are shown. The only solution seems to be
deleting "_site" directory.