### PR TITLE
Weld 2.4.8.Final release notes. Also fixing symlinks for latest.

### DIFF
--- a/_config/releases.yml
+++ b/_config/releases.yml
@@ -1,3 +1,7 @@
+- version: '2.4.8.Final'
+  category: Final
+  date: 26.09.2018
+  versionId: 12337222
 - version: '3.0.5.Final'
   category: Final
   date: 27.07.2018

--- a/community.html.haml
+++ b/community.html.haml
@@ -79,7 +79,7 @@ desc: Useful links to source code repository, issue tracker, user forum, mailing
       first ;-)
     %li
       fix or expand our
-      %a{:href=>"http://docs.jboss.org/weld/reference/latest-master/en-US/html/"}
+      %a{:href=>"http://docs.jboss.org/weld/reference/latest/en-US/html/"}
         reference documentation
     %li
       expand our

--- a/documentation.html.haml
+++ b/documentation.html.haml
@@ -12,11 +12,11 @@ desc: FAQ, Links to Weld documentation
     The latest Weld 3 version:
     %ul
       %li
-        %a{:href=>"http://docs.jboss.org/weld/reference/latest-master/en-US/html/",:target=>'_blank'}HTML
+        %a{:href=>"http://docs.jboss.org/weld/reference/latest/en-US/html/",:target=>'_blank'}HTML
       %li
-        %a{:href=>"http://docs.jboss.org/weld/reference/latest-master/en-US/html_single/",:target=>'_blank'}HTML (Single page)
+        %a{:href=>"http://docs.jboss.org/weld/reference/latest/en-US/html_single/",:target=>'_blank'}HTML (Single page)
       %li
-        %a{:href=>"http://docs.jboss.org/weld/reference/latest-master/en-US/pdf/weld-reference.pdf",:target=>'_blank'}PDF
+        %a{:href=>"http://docs.jboss.org/weld/reference/latest/en-US/pdf/weld-reference.pdf",:target=>'_blank'}PDF
   %li
     %a{:href=>"http://docs.jboss.org/weld/reference/",:target=>"_blank"}Browse documentation for older Weld releases
 

--- a/index.html.haml
+++ b/index.html.haml
@@ -32,9 +32,9 @@ desc: Weld - CDI Reference Implementation
           %a{:href=>"http://www.oracle.com/technetwork/middleware/weblogic/overview/index.html",:target=>'_blank'}Oracle WebLogic Server
         %a{:href=>"https://developer.ibm.com/wasdev/downloads/",:target=>'_blank'}WebSphere Application Server
         and others. Weld can also be used in plain
-        %a{:href=>"http://docs.jboss.org/weld/reference/latest-master/en-US/html/environments.html#weld-servlet",:target=>'_blank'}servlet containers (Tomcat, Jetty)
+        %a{:href=>"http://docs.jboss.org/weld/reference/latest/en-US/html/environments.html#weld-servlet",:target=>'_blank'}servlet containers (Tomcat, Jetty)
         or
-        %a{:href=>"http://docs.jboss.org/weld/reference/latest-master/en-US/html/environments.html#weld-se",:target=>'_blank'}Java SE.
+        %a{:href=>"http://docs.jboss.org/weld/reference/latest/en-US/html/environments.html#weld-se",:target=>'_blank'}Java SE.
       %h2 Try Weld Today
       %div
         %p
@@ -80,6 +80,17 @@ desc: Weld - CDI Reference Implementation
           %tbody
             %tr
               %td
+                WildFly 14.0.0.Final
+              %td
+                Weld 3.0.5.Final
+                %span{:class=>"label label-primary"}
+                  CDI 2.0
+              %td
+                %ul
+                  %li
+                    None available
+            %tr
+              %td
                 WildFly 13.0.0.Final
               %td
                 Weld 3.0.4.Final
@@ -95,8 +106,6 @@ desc: Weld - CDI Reference Implementation
                 %ul
                   %li
                     None available
-            %tr
-              %td
             %tr
               %td
                 WildFly 12.0.0.Final
@@ -124,7 +133,7 @@ desc: Weld - CDI Reference Implementation
               %td
                 %ul
                   %li
-                    %a{:href=>"http://download.jboss.org/weld/2.4.7.Final/wildfly-11.0.0.Final-weld-2.4.7.Final-patch.zip"}Weld 2.4.7.Final
+                    %a{:href=>"http://download.jboss.org/weld/2.4.8.Final/wildfly-11.0.0.Final-weld-2.4.8.Final-patch.zip"}Weld 2.4.8.Final
                     %span{:class=>"label label-primary"}
                       CDI 1.2
                   %li

--- a/news/2015-08-05-weld-300Alpha12.asciidoc
+++ b/news/2015-08-05-weld-300Alpha12.asciidoc
@@ -47,7 +47,7 @@ This looks very similar to CDI SE, right? However, there are several advanced fe
 ** `WeldContainer container = new Weld().disableDiscovery().beanClasses(Foo.class, Bar.class).alternatives(Bar.class).interceptors(FooInterceptor.class).initialize();`
 * WeldContainer allows to fire events easily
 ** `container.event().select(Bar.class).fire(new Bar());`
-* Weld-specific link:http://docs.jboss.org/weld/reference/latest-master/en-US/html/configure.html#_weld_configuration[configuration options] can be specified using the builder
+* Weld-specific link:http://docs.jboss.org/weld/reference/latest/en-US/html/configure.html#_weld_configuration[configuration options] can be specified using the builder
 * it is possible to start multiple independent Weld instances (specification does not require this)
 
 See also link:http://weld.cdi-spec.org/news/2015/04/21/weld-300Alpha8/[Weld 3.0.0.Alpha8 announcement] for more information.

--- a/news/2017-05-19-tour-around-weld-3.asciidoc
+++ b/news/2017-05-19-tour-around-weld-3.asciidoc
@@ -90,7 +90,7 @@ Following configurators were added:
 * `ObserverMethodConfigurator`
 * `ProducerConfigurator`
 
-On top of that, Weld adds one additional configurator - link:http://docs.jboss.org/weld/reference/latest-master/en-US/html_single/#_weld_enriched_container_lifecycle_events[`InterceptorConfigurator`, window="_blank"].
+On top of that, Weld adds one additional configurator - link:http://docs.jboss.org/weld/reference/latest/en-US/html_single/#_weld_enriched_container_lifecycle_events[`InterceptorConfigurator`, window="_blank"].
 This one allows you to observe `WeldAfterBeanDiscovery` and then use this configurator to create and register a custom interceptor from scratch.
 
 == SE Bootstrap API
@@ -201,7 +201,7 @@ Last but not least feature we will mention are so called 'trimmed' bean archives
 You can mark an explicit bean archive as trimmed in `beans.xml` by adding the `</trim>` element.
 Such bean archive will perform an annotated type discovery as with `bean-discovery-mode="all"` but all types that don't have a bean defining annotation or any scope annotation are then removed from the set of discovered types.
 
-Even in this case, Weld allows you to go one step further and link:http://docs.jboss.org/weld/reference/latest-master/en-US/html/configure.html#veto-types-without-bean-defining-annotation[veto types based on regular expression].
+Even in this case, Weld allows you to go one step further and link:http://docs.jboss.org/weld/reference/latest/en-US/html/configure.html#veto-types-without-bean-defining-annotation[veto types based on regular expression].
 It works on a similar principle but affects your whole application - it processess all types from all bean archives.
 Your archives will be scanned as they would be with bean discovery mode `all` and `ProcessAnnotatedType` will be fired for all found annotated types.
 Then, based on the regular expression you provide, annotated types which do not have a bean defining annotation and match the regular expression will be vetoed.

--- a/news/2018-09-26-weld-248Final.asciidoc
+++ b/news/2018-09-26-weld-248Final.asciidoc
@@ -1,0 +1,43 @@
+---
+layout: news
+title: Weld 2.4.8.Final
+author: Matej Novotny
+priority: 1
+change_frequency: weekly
+excerpt: Weld 2.4.8.Final released
+desc: Weld 2.4.8.Final released
+tags: [release]
+---
+:linkattrs:
+
+Weld 2 has entered maintenance mode with its 2.4.7.Final release earlier this year.
+Now we are coming with a maintenance release containing fixes to several nuisances you might have come across.
+
+Notable fixes and improvements:
+
+* Weld Core:
+** Opt-in enhancement in HTTP session replication, more eager approach (link:https://issues.jboss.org/browse/WELD-1130[WELD-1130, window="_blank"])
+*** Note that WildFly does not need to use this
+** `AfterTypeDiscovery` did not allow to remove declared interceptors/decorators/alternatives correctly (link:https://issues.jboss.org/browse/WELD-2479[WELD-2479, window="_blank"])
+** Corrected decorator subclass creation when said decorator overrides only default method (link:https://issues.jboss.org/browse/WELD-2501[WELD-2501, window="_blank"])
+** Avoid optimizing self invocation of private methods in order to avoid `IllegalAccessError`(link:https://issues.jboss.org/browse/WELD-2506[WELD-2506, window="_blank"])
+** Allow interception of abstract, package-private classes with public methods (link:https://issues.jboss.org/browse/WELD-2507[WELD-2507, window="_blank"])
+** Fix interception of overriden generic methods invoked via superclass (link:https://issues.jboss.org/browse/WELD-2514[WELD-2514, window="_blank"])
+** Implement reflection fallback for qualifier loading when there are multiple instances of the class in the deployment (link:https://issues.jboss.org/browse/WELD-2531[WELD-2531, window="_blank"])
+** Fixed possible race condition appearing during bean index creation (link:https://issues.jboss.org/browse/WELD-2532[WELD-2532, window="_blank"])
+
+* Weld SE
+** Fix NPE which could occur if trying to intercept a method called by constructor (link:https://issues.jboss.org/browse/WELD-2473[WELD-2473, window="_blank"] and link:https://issues.jboss.org/browse/WELD-2478[WELD-2478, window="_blank"])
+
+
+* Other
+** Correction to licenses in Probe (link:https://issues.jboss.org/browse/WELD-2480[WELD-2480, window="_blank"])
+
+== WildFly Patch
+
+As usual, a link:http://download.jboss.org/weld/2.4.8.Final/wildfly-11.0.0.Final-weld-2.4.8.Final-patch.zip[patch for WildFly 11.0.0.Final, window="_blank"] is available.
+If you’re not familiar with patching WildFly, check the link:/documentation/#12[FAQ].
+
+&#91; link:/download/[Download] &#93;
+&#91; link:http://docs.jboss.org/weld/reference/2.4.8.Final/en-US/html/[Documentation, window="_blank"] &#93;
+&#91; link:https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12310891&version=12337222[Release notes, window="_blank"] &#93;


### PR DESCRIPTION
Contains release notes for 2.4.8.Final as well as agreed removal on `latest-master` symlink and it's replacement with plain `latest` symlink.