### PR TITLE
WELD-2621 Allow pages without tags.

### DIFF
--- a/_layouts/news.html.haml
+++ b/_layouts/news.html.haml
@@ -8,7 +8,7 @@ layout: base
       %i.fa.fa-rss
   %div.news-date.news-boxed
     #{page.date.year}-#{page.date.month}-#{page.date.day}
-    - if (page.tags.length > 0)
+    - if (page.tags != nil && page.tags.length > 0)
       &nbsp;
       %span.tags
         %i.fa.fa-tags

--- a/news/index.html.haml
+++ b/news/index.html.haml
@@ -18,7 +18,7 @@ desc: Latest news about Weld.
     - if (post.content.length > 0)
       %div.news-date.news-boxed
         #{post.date.year}-#{post.date.month}-#{post.date.day}
-        - if (post.tags.length > 0)
+        - if (post.tags != nil && post.tags.length > 0)
           &nbsp;
           %span.tags
             %i.fa.fa-tags


### PR DESCRIPTION
Looks like the issue was with some methods being invoked on `nil`. Apparently earlier versions were more permissive in checks.

Some of our older posts didn't have any tags (either weren't using them or it didn't make sense to have them there) and this caused some errors.