### PR TITLE
Release notes for Weld 7.0.0.Beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,15 @@ Create a new file in `content/posts/` following the naming convention
 layout: post
 title: Your Post Title
 author: Your Name
+description: Short summary used in the RSS feed
 tags: [release]
 ---
 ```
+
+- `description` is used by the RSS feed (`rss.xml`). Keep it concise.
+- `tags` are not currently rendered on the site but are preserved for
+  future use (e.g. filtering). Common values: `release`, `team`, `tips`,
+  `testing`, `integration`. Multiple tags are supported: `[release, jakarta]`.
 
 Submit a pull request. On merge, the site is rebuilt and deployed automatically.
 

--- a/content/posts/2013-04-25-weld-200-final.asciidoc
+++ b/content/posts/2013-04-25-weld-200-final.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 2.0.0.Final released
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 aliases: [/news/2013/04/25/weld-200-final/]
 ---
 

--- a/content/posts/2013-06-06-weld-201-final.asciidoc
+++ b/content/posts/2013-06-06-weld-201-final.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 2.0.1.Final
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 aliases: [/news/2013/06/06/weld-201-final/]
 ---
 

--- a/content/posts/2013-06-20-new-weld-site.asciidoc
+++ b/content/posts/2013-06-20-new-weld-site.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld has a new web site!
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
 aliases: [/news/2013/06/20/new-weld-site/]
 ---
 :excerpt: Weld has a new web site and it's built with Awestruct!

--- a/content/posts/2013-09-20-weld-210beta2-tip.asciidoc
+++ b/content/posts/2013-09-20-weld-210beta2-tip.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 2.1.0.Beta2 tip
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
 aliases: [/news/2013/09/20/weld-210beta2-tip/]
 ---
 :excerpt: A tip how to skip CDI context activation for some HTTP requests...

--- a/content/posts/2013-10-22-weld-210-final.asciidoc
+++ b/content/posts/2013-10-22-weld-210-final.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 2.1.0.Final
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 aliases: [/news/2013/10/22/weld-210-final/]
 ---
 

--- a/content/posts/2013-12-11-weld-211-final.asciidoc
+++ b/content/posts/2013-12-11-weld-211-final.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 2.1.1.Final
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 aliases: [/news/2013/12/11/weld-211-final/]
 ---
 

--- a/content/posts/2014-01-14-weld-212-final.asciidoc
+++ b/content/posts/2014-01-14-weld-212-final.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Three new Weld releases
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 aliases: [/news/2014/01/14/weld-212-final/]
 ---
 

--- a/content/posts/2014-02-04-weld-220-alpha1.asciidoc
+++ b/content/posts/2014-02-04-weld-220-alpha1.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: CDI 1.2 and Weld 2.2
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 aliases: [/news/2014/02/04/weld-220-alpha1/]
 ---
 

--- a/content/posts/2014-04-15-weld-220-final.asciidoc
+++ b/content/posts/2014-04-15-weld-220-final.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 2.2 (CDI 1.2 reference implementation) released!
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 aliases: [/news/2014/04/15/weld-220-final/]
 ---
 

--- a/content/posts/2014-09-18-weld-next.asciidoc
+++ b/content/posts/2014-09-18-weld-next.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld.Next
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 aliases: [/news/2014/09/18/weld-next/]
 ---
 

--- a/content/posts/2014-10-02-weld-300Alpha1.asciidoc
+++ b/content/posts/2014-10-02-weld-300Alpha1.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 3.0.0.Alpha1 released!
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 aliases: [/news/2014/10/02/weld-300Alpha1/]
 ---
 

--- a/content/posts/2014-12-10-an-update-on-weld-3.asciidoc
+++ b/content/posts/2014-12-10-an-update-on-weld-3.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: An update on Weld 3
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 tags: [cdi2]
 aliases: [/news/2014/12/10/an-update-on-weld-3/]
 ---

--- a/content/posts/2015-02-05-weld-300Alpha4.asciidoc
+++ b/content/posts/2015-02-05-weld-300Alpha4.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 3.0.0.Alpha4
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 tags: [release, cdi2]
 aliases: [/news/2015/02/05/weld-300Alpha4/]
 ---

--- a/content/posts/2015-02-25-weld-300Alpha5.asciidoc
+++ b/content/posts/2015-02-25-weld-300Alpha5.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 3.0.0.Alpha5
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 tags: [release, cdi2]
 aliases: [/news/2015/02/25/weld-300Alpha5/]
 ---

--- a/content/posts/2015-04-21-weld-300Alpha8.asciidoc
+++ b/content/posts/2015-04-21-weld-300Alpha8.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 3.0.0.Alpha8
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 tags: [release, cdi2]
 aliases: [/news/2015/04/21/weld-300Alpha8/]
 ---

--- a/content/posts/2015-08-05-weld-300Alpha12.asciidoc
+++ b/content/posts/2015-08-05-weld-300Alpha12.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 3.0.0.Alpha12 - CDI 2.0 EDR1 Reference Implementation!
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
 tags: [release, cdi2]
 aliases: [/news/2015/08/05/weld-300Alpha12/]
 ---

--- a/content/posts/2015-09-08-weld-team-changes.asciidoc
+++ b/content/posts/2015-09-08-weld-team-changes.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld team changes
 author: Jozef Hartinger
-priority: 1
-change_frequency: weekly
 tags: [team]
 aliases: [/news/2015/09/08/weld-team-changes/]
 ---

--- a/content/posts/2015-09-15-jdk-8u60-problem.asciidoc
+++ b/content/posts/2015-09-15-jdk-8u60-problem.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: JDK 8u60 reveals a problem in Weld
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
 tags: [bug, jdk]
 aliases: [/news/2015/09/15/jdk-8u60-problem/]
 ---

--- a/content/posts/2015-09-18-weld-230Final.asciidoc
+++ b/content/posts/2015-09-18-weld-230Final.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 2.3.0.Final released!
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
 tags: [release]
 aliases: [/news/2015/09/18/weld-230Final/]
 ---

--- a/content/posts/2015-10-27-weld-231Final.asciidoc
+++ b/content/posts/2015-10-27-weld-231Final.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 2.3.1.Final arrives...
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
 tags: [release]
 aliases: [/news/2015/10/27/weld-231Final/]
 ---

--- a/content/posts/2015-11-10-weld-probe-jmx.asciidoc
+++ b/content/posts/2015-11-10-weld-probe-jmx.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld development mode and JMX support
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
 tags: [probe, jmx]
 aliases: [/news/2015/11/10/weld-probe-jmx/]
 ---

--- a/content/posts/2015-11-25-arq-container-se-CR1.asciidoc
+++ b/content/posts/2015-11-25-arq-container-se-CR1.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Arquillian container SE 1.0.0.CR1 released!
 author: Tomas Remes
-priority: 1
-change_frequency: weekly
 tags: [arquillian, testing]
 aliases: [/news/2015/11/25/arq-container-se-CR1/]
 ---

--- a/content/posts/2015-12-04-weld-300Alpha14.asciidoc
+++ b/content/posts/2015-12-04-weld-300Alpha14.asciidoc
@@ -2,9 +2,7 @@
 layout: post
 title: Weld 3.0.0.Alpha14
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-desc: Weld 3.0.0.Alpha14 released.
+description: Weld 3.0.0.Alpha14 released.
 tags: [release, cdi2]
 aliases: [/news/2015/12/04/weld-300Alpha14/]
 ---

--- a/content/posts/2015-12-10-weld-232Final.asciidoc
+++ b/content/posts/2015-12-10-weld-232Final.asciidoc
@@ -2,9 +2,7 @@
 layout: post
 title: Weld 2.3.2.Final
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-desc: Weld 2.3.2.Final released.
+description: Weld 2.3.2.Final released.
 tags: [release]
 aliases: [/news/2015/12/10/weld-232Final/]
 ---

--- a/content/posts/2016-02-04-weld-300Alpha15.asciidoc
+++ b/content/posts/2016-02-04-weld-300Alpha15.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.0.0.Alpha15
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: The next experimental Weld version has been released.
-desc: Weld 3.0.0.Alpha15 released. ExperimentalAfterBeanDiscovery event has been enhanced.
+description: Weld 3.0.0.Alpha15 released. ExperimentalAfterBeanDiscovery event has been enhanced.
 tags: [release, cdi2]
 aliases: [/news/2016/02/04/weld-300Alpha15/]
 ---

--- a/content/posts/2016-02-08-weld-se-synth-lifecycle-events.asciidoc
+++ b/content/posts/2016-02-08-weld-se-synth-lifecycle-events.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld SE and synthetic container lifecycle event observers
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: A new experimental feature of Weld SE planned for 3.0.0.Alpha16.
-desc: Weld SE 3.x introducing synthetic lifecycle event observer.
+description: Weld SE 3.x introducing synthetic lifecycle event observer.
 tags: [api, draft]
 aliases: [/news/2016/02/08/weld-se-synth-lifecycle-events/]
 ---

--- a/content/posts/2016-02-12-weld-233Final.asciidoc
+++ b/content/posts/2016-02-12-weld-233Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 2.3.3.Final
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: The next bug-fix release for the stable 2.3 branch (CDI 1.2 implementation) has been released.
-desc: Weld 2.3.3.Final released
+description: Weld 2.3.3.Final released
 tags: [release]
 aliases: [/news/2016/02/12/weld-233Final/]
 ---

--- a/content/posts/2016-04-11-weld-meets-vertx.asciidoc
+++ b/content/posts/2016-04-11-weld-meets-vertx.asciidoc
@@ -2,9 +2,7 @@
 layout: post
 title: Weld meets Vert.x
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-desc: Weld meets Vert.x
+description: Weld meets Vert.x
 tags: [vertx, integration]
 aliases: [/news/2016/04/11/weld-meets-vertx/]
 ---

--- a/content/posts/2016-04-22-weld-234Final.asciidoc
+++ b/content/posts/2016-04-22-weld-234Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 2.3.4.Final
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: The next version of the stable 2.3 branch (CDI 1.2, WildFly 10) has been released.
-desc: Weld 2.3.4.Final released
+description: Weld 2.3.4.Final released
 tags: [release]
 aliases: [/news/2016/04/22/weld-234Final/]
 ---

--- a/content/posts/2016-04-28-weld-300Alpha16.asciidoc
+++ b/content/posts/2016-04-28-weld-300Alpha16.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.0.0.Alpha16
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: Start playing with metadata configurators included in the next experimental version of Weld (aligned with CDI 2.0.Alpha4).
-desc: Weld 3.0.0.Alpha16 released
+description: Weld 3.0.0.Alpha16 released
 tags: [release, cdi2]
 aliases: [/news/2016/04/28/weld-300Alpha16/]
 ---

--- a/content/posts/2016-05-18-enhanced-instance.asciidoc
+++ b/content/posts/2016-05-18-enhanced-instance.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Programmatic lookup improvements
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: Weld team is considering adding an enhanced version of javax.enterprise.inject.Instance to the Weld API. Explore the possibilities...
-desc: Experiments with enhanced version of javax.enterprise.inject.Instance
+description: Experiments with enhanced version of javax.enterprise.inject.Instance
 tags: [api, draft]
 aliases: [/news/2016/05/18/enhanced-instance/]
 ---

--- a/content/posts/2016-06-21-update-on-weld-vertx.asciidoc
+++ b/content/posts/2016-06-21-update-on-weld-vertx.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Update on weld-vertx
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: Weld team has just released the first version of weld-vertx. Check the new features and explore the possibilities.
-desc: Weld team has just released the first version of weld-vertx. Check the new features and explore the possibilities.
+description: Weld team has just released the first version of weld-vertx. Check the new features and explore the possibilities.
 tags: [vertx, integration]
 aliases: [/news/2016/06/21/update-on-weld-vertx/]
 ---

--- a/content/posts/2016-07-01-weld-235Final.asciidoc
+++ b/content/posts/2016-07-01-weld-235Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 2.3.5.Final
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: The next version of the stable 2.3 branch (CDI 1.2, WildFly 10) has been released.
-desc: Weld 2.3.5.Final released
+description: Weld 2.3.5.Final released
 tags: [release, plans]
 aliases: [/news/2016/07/01/weld-235Final/]
 ---

--- a/content/posts/2016-07-21-arq-container-weld-releasel.asciidoc
+++ b/content/posts/2016-07-21-arq-container-weld-releasel.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Arquillian container Weld 2.0.0.Beta1 released!
 author: Tomas Remes
-priority: 1
-change_frequency: weekly
 tags: [arquillian, testing]
 aliases: [/news/2016/07/21/arq-container-weld-releasel/]
 ---

--- a/content/posts/2016-08-19-weld-240CR1.asciidoc
+++ b/content/posts/2016-08-19-weld-240CR1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: First release candidate of Weld 2.4
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: The first release candidate of the 2.4 branch (CDI 1.2) has been released.
-desc: Weld 2.4.0.CR1 released
+description: Weld 2.4.0.CR1 released
 tags: [release]
 aliases: [/news/2016/08/19/weld-240CR1/]
 ---

--- a/content/posts/2016-09-13-weld-240Final.asciidoc
+++ b/content/posts/2016-09-13-weld-240Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 2.4.0.Final
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: The first stable version of the 2.4 branch (CDI 1.2) arrived.
-desc: Weld 2.4.0.Final released
+description: Weld 2.4.0.Final released
 tags: [release]
 aliases: [/news/2016/09/13/weld-240Final/]
 ---

--- a/content/posts/2016-10-01-tip1-logging.asciidoc
+++ b/content/posts/2016-10-01-tip1-logging.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld Tip 1 - Logging
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: The very first article from a series of concise Weld tips.
-desc: Weld Tips 1 - Logging
+description: Weld Tips 1 - Logging
 tags: [tips]
 aliases: [/news/2016/10/01/tip1-logging/]
 ---

--- a/content/posts/2016-10-07-tip2-devmode.asciidoc
+++ b/content/posts/2016-10-07-tip2-devmode.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld Tip 2 - Development Mode
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: Meet Weld Probe - a development tool which allows to inspect CDI components at runtime.
-desc: Weld Tip 2 - Development Mode
+description: Weld Tip 2 - Development Mode
 tags: [tips]
 aliases: [/news/2016/10/07/tip2-devmode/]
 ---

--- a/content/posts/2016-10-25-tip3-performance.asciidoc
+++ b/content/posts/2016-10-25-tip3-performance.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld Tip 3 - Boost performance of Weld apps
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: Explore various aspects of CDI/Weld applications performance.
-desc: Weld Tip 3 - Boost performance of Weld apps
+description: Weld Tip 3 - Boost performance of Weld apps
 tags: [tips]
 aliases: [/news/2016/10/25/tip3-performance/]
 ---

--- a/content/posts/2016-11-18-weld-241Final.asciidoc
+++ b/content/posts/2016-11-18-weld-241Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 2.4.1.Final
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: The development of Weld 3 (CDI 2) is underway. But for now the first bugfix version of Weld 2.4 (CDI 1.2) is landing.
-desc: Weld 2.4.1.Final released
+description: Weld 2.4.1.Final released
 tags: [release]
 aliases: [/news/2016/11/18/weld-241Final/]
 ---

--- a/content/posts/2016-12-19-weld-300Beta1.asciidoc
+++ b/content/posts/2016-12-19-weld-300Beta1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.0.0.Beta1
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.0.0.Beta1 (CDI 2.0.Beta1) done. We're almost there!
-desc: Weld 3.0.0.Beta1 released
+description: Weld 3.0.0.Beta1 released
 tags: [release]
 aliases: [/news/2016/12/19/weld-300Beta1/]
 ---

--- a/content/posts/2017-01-23-weld-300CR1.asciidoc
+++ b/content/posts/2017-01-23-weld-300CR1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.0.0.CR1
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.0.0.CR1 (CDI 2.0-PFD) released. And it's almost Final!
-desc: Weld 3.0.0.CR1 released
+description: Weld 3.0.0.CR1 released
 tags: [release]
 aliases: [/news/2017/01/23/weld-300CR1/]
 ---

--- a/content/posts/2017-02-01-tip4-testing.asciidoc
+++ b/content/posts/2017-02-01-tip4-testing.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld Tip 4 - Testing CDI/Weld apps
 author: Tomas Remes, Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Taking a dive into CDI/Weld application testing.
-desc: Weld Tip 4 - Testing CDI/Weld apps
+description: Weld Tip 4 - Testing CDI/Weld apps
 tags: [tips]
 aliases: [/news/2017/02/01/tip4-testing/]
 ---

--- a/content/posts/2017-02-02-weld-242Final.asciidoc
+++ b/content/posts/2017-02-02-weld-242Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 2.4.2.Final
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: Another bugfix version of Weld 2.4 (CDI 1.2) is here. Today with some CDI 2 stuff!
-desc: Weld 2.4.2.Final released
+description: Weld 2.4.2.Final released
 tags: [release]
 aliases: [/news/2017/02/02/weld-242Final/]
 ---

--- a/content/posts/2017-03-03-weld-300CR2.asciidoc
+++ b/content/posts/2017-03-03-weld-300CR2.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.0.0.CR2
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: Please welcome the second candidate release for Weld 3 (CDI 2.0-PFD)!
-desc: Please welcome the second candidate release for Weld 3 (CDI 2.0-PFD)!
+description: Please welcome the second candidate release for Weld 3 (CDI 2.0-PFD)!
 tags: [release]
 aliases: [/news/2017/03/03/weld-300CR2/]
 ---

--- a/content/posts/2017-04-07-weld-243Final.asciidoc
+++ b/content/posts/2017-04-07-weld-243Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 2.4.3.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Make way for Weld 2.4.3.Final!
-desc: Weld 2.4.3.Final released
+description: Weld 2.4.3.Final released
 tags: [release]
 aliases: [/news/2017/04/07/weld-243Final/]
 ---

--- a/content/posts/2017-05-15-weld-300Final.asciidoc
+++ b/content/posts/2017-05-15-weld-300Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.0.0.Final - the first implementation of CDI 2.0!
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3 finally comes to the party. CDI 1.2 is dead, long live CDI 2.0!
-desc: Weld 3.0.0.Final released. Try out the first implementation of the CDI 2.0 spec!
+description: Weld 3.0.0.Final released. Try out the first implementation of the CDI 2.0 spec!
 tags: [release]
 aliases: [/news/2017/05/15/weld-300Final/]
 ---

--- a/content/posts/2017-05-19-tour-around-weld-3.asciidoc
+++ b/content/posts/2017-05-19-tour-around-weld-3.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Tour around Weld 3
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Tour around the new stuff in Weld 3
-desc: A summary of CDI 2.0 features coated with Weld and sprinkled with code samples
+description: A summary of CDI 2.0 features coated with Weld and sprinkled with code samples
 aliases: [/news/2017/05/19/tour-around-weld-3/]
 ---
 :linkattrs:

--- a/content/posts/2017-06-14-weld-244Final.asciidoc
+++ b/content/posts/2017-06-14-weld-244Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 2.4.4.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Watch out, Weld 2.4.4.Final coming through!
-desc: Weld 2.4.4.Final released
+description: Weld 2.4.4.Final released
 tags: [release]
 aliases: [/news/2017/06/14/weld-244Final/]
 ---

--- a/content/posts/2017-08-07-weld-vertx-next.asciidoc
+++ b/content/posts/2017-08-07-weld-vertx-next.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld Vert.x Next?
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
-excerpt: Last year Weld team announced the weld-vertx project. It's a good time to summarize the features and plans for future.
-desc: Last year Weld team announced the weld-vertx project. It's a good time to summarize the features and plans for future.
+description: Last year Weld team announced the weld-vertx project. It's a good time to summarize the features and plans for future.
 tags: [vertx, integration]
 aliases: [/news/2017/08/07/weld-vertx-next/]
 ---

--- a/content/posts/2017-08-25-weld-301Final.asciidoc
+++ b/content/posts/2017-08-25-weld-301Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.0.1.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: First round of bug smashing for Weld 3!
-desc: Weld 3.0.1.Final released
+description: Weld 3.0.1.Final released
 tags: [release]
 aliases: [/news/2017/08/25/weld-301Final/]
 ---

--- a/content/posts/2017-09-11-weld-245Final.asciidoc
+++ b/content/posts/2017-09-11-weld-245Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 2.4.5.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 2.4.5.Final released
-desc: Weld 2.4.5.Final released
+description: Weld 2.4.5.Final released
 tags: [release]
 aliases: [/news/2017/09/11/weld-245Final/]
 ---

--- a/content/posts/2017-11-23-weld-302Final.asciidoc
+++ b/content/posts/2017-11-23-weld-302Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.0.2.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Watch out, Weld 3 release is coming your way!
-desc: Weld 3.0.2.Final released
+description: Weld 3.0.2.Final released
 tags: [release]
 aliases: [/news/2017/11/23/weld-302Final/]
 ---

--- a/content/posts/2017-12-18-weld-246Final.asciidoc
+++ b/content/posts/2017-12-18-weld-246Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 2.4.6.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 2.4.6.Final released
-desc: Weld 2.4.6.Final released
+description: Weld 2.4.6.Final released
 tags: [release]
 aliases: [/news/2017/12/18/weld-246Final/]
 ---

--- a/content/posts/2017-12-19-weld-meets-junit5.asciidoc
+++ b/content/posts/2017-12-19-weld-meets-junit5.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld meets JUnit 5
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: What if you could easily write JUnit 5 tests for Weld beans?
-desc: What if you could easily write JUnit 5 tests for Weld beans?
+description: What if you could easily write JUnit 5 tests for Weld beans?
 tags: [junit, testing, weld-se]
 aliases: [/news/2017/12/19/weld-meets-junit5/]
 ---

--- a/content/posts/2018-02-09-weld-303Final.asciidoc
+++ b/content/posts/2018-02-09-weld-303Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.0.3.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.0.3.Final released
-desc: Weld 3.0.3.Final released
+description: Weld 3.0.3.Final released
 tags: [release]
 aliases: [/news/2018/02/09/weld-303Final/]
 ---

--- a/content/posts/2018-03-20-weld-247Final.asciidoc
+++ b/content/posts/2018-03-20-weld-247Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 2.4.7.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 2.4.7.Final released
-desc: Weld 2.4.7.Final released
+description: Weld 2.4.7.Final released
 tags: [release]
 aliases: [/news/2018/03/20/weld-247Final/]
 ---

--- a/content/posts/2018-04-26-weld-304Final.asciidoc
+++ b/content/posts/2018-04-26-weld-304Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.0.4.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.0.4.Final released
-desc: Weld 3.0.4.Final released
+description: Weld 3.0.4.Final released
 tags: [release]
 aliases: [/news/2018/04/26/weld-304Final/]
 ---

--- a/content/posts/2018-07-10-weld-team-changes.asciidoc
+++ b/content/posts/2018-07-10-weld-team-changes.asciidoc
@@ -3,8 +3,6 @@ layout: post
 title: Weld team changes
 slug: weld-team-changes-2018
 author: Martin Kouba
-priority: 1
-change_frequency: weekly
 tags: [team]
 aliases: [/news/2018/07/10/weld-team-changes/]
 ---

--- a/content/posts/2018-07-26-weld-305Final.asciidoc
+++ b/content/posts/2018-07-26-weld-305Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.0.5.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.0.5.Final released
-desc: Weld 3.0.5.Final released
+description: Weld 3.0.5.Final released
 tags: [release]
 aliases: [/news/2018/07/26/weld-305Final/]
 ---

--- a/content/posts/2018-09-26-weld-248Final.asciidoc
+++ b/content/posts/2018-09-26-weld-248Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 2.4.8.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 2.4.8.Final released
-desc: Weld 2.4.8.Final released
+description: Weld 2.4.8.Final released
 tags: [release]
 aliases: [/news/2018/09/26/weld-248Final/]
 ---

--- a/content/posts/2019-02-06-weld-310Final.asciidoc
+++ b/content/posts/2019-02-06-weld-310Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.1.0.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.1.0.Final released
-desc: Weld 3.1.0.Final released
+description: Weld 3.1.0.Final released
 tags: [release]
 aliases: [/news/2019/02/06/weld-310Final/]
 ---

--- a/content/posts/2019-05-07-weld-311Final.asciidoc
+++ b/content/posts/2019-05-07-weld-311Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.1.1.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.1.1.Final released
-desc: Weld 3.1.1.Final released
+description: Weld 3.1.1.Final released
 tags: [release]
 aliases: [/news/2019/05/07/weld-311Final/]
 ---

--- a/content/posts/2019-08-06-weld-312Final.asciidoc
+++ b/content/posts/2019-08-06-weld-312Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.1.2.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.1.2.Final released
-desc: Weld 3.1.2.Final released
+description: Weld 3.1.2.Final released
 tags: [release]
 aliases: [/news/2019/08/06/weld-312Final/]
 ---

--- a/content/posts/2019-11-28-weld-313Final.asciidoc
+++ b/content/posts/2019-11-28-weld-313Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.1.3.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.1.3.Final released
-desc: Weld 3.1.3.Final released
+description: Weld 3.1.3.Final released
 tags: [release]
 aliases: [/news/2019/11/28/weld-313Final/]
 ---

--- a/content/posts/2020-03-28-weld-314Final.asciidoc
+++ b/content/posts/2020-03-28-weld-314Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.1.4.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.1.4.Final released
-desc: Weld 3.1.4.Final released
+description: Weld 3.1.4.Final released
 tags: [release]
 aliases: [/news/2020/03/28/weld-314Final/]
 ---

--- a/content/posts/2020-05-13-weld-jakarta-ee-9.asciidoc
+++ b/content/posts/2020-05-13-weld-jakarta-ee-9.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Weld 4 and Jakarta EE 9
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
 tags: [release, jakarta]
 aliases: [/news/2020/05/13/weld-jakarta-ee-9/]
 ---

--- a/content/posts/2020-08-12-weld-315Final.asciidoc
+++ b/content/posts/2020-08-12-weld-315Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.1.5.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.1.5.Final released
-desc: Weld 3.1.5.Final released
+description: Weld 3.1.5.Final released
 tags: [release]
 aliases: [/news/2020/08/12/weld-315Final/]
 ---

--- a/content/posts/2020-09-18-weld-400Beta1.asciidoc
+++ b/content/posts/2020-09-18-weld-400Beta1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 4.0.0.Beta1
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 4.0.0.Beta1 released
-desc: Weld 4.0.0.Beta1 released
+description: Weld 4.0.0.Beta1 released
 tags: [release]
 aliases: [/news/2020/09/18/weld-400Beta1/]
 ---

--- a/content/posts/2020-12-16-weld-400Final.asciidoc
+++ b/content/posts/2020-12-16-weld-400Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 4.0.0.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 4.0.0.Final released
-desc: Weld 4.0.0.Final released
+description: Weld 4.0.0.Final released
 tags: [release]
 aliases: [/news/2020/12/16/weld-400Final/]
 ---

--- a/content/posts/2021-01-13-weld-316Final.asciidoc
+++ b/content/posts/2021-01-13-weld-316Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.1.6.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.1.6.Final has been released
-desc: Weld 3.1.6.Final has been released
+description: Weld 3.1.6.Final has been released
 tags: [release]
 aliases: [/news/2021/01/13/weld-316Final/]
 ---

--- a/content/posts/2021-03-18-weld-317Final.asciidoc
+++ b/content/posts/2021-03-18-weld-317Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 3.1.7.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 3.1.7.Final has been released
-desc: Weld 3.1.7.Final has been released
+description: Weld 3.1.7.Final has been released
 tags: [release]
 aliases: [/news/2021/03/18/weld-317Final/]
 ---

--- a/content/posts/2021-03-22-weld-401Final.asciidoc
+++ b/content/posts/2021-03-22-weld-401Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 4.0.1.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 4.0.1.Final has been released
-desc: Weld 4.0.1.Final has been released
+description: Weld 4.0.1.Final has been released
 tags: [release]
 aliases: [/news/2021/03/22/weld-401Final/]
 ---

--- a/content/posts/2021-04-14-weld-401SP1-317SP1.asciidoc
+++ b/content/posts/2021-04-14-weld-401SP1-317SP1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 4.0.1.SP1 and 3.1.7.SP1
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 4.0.1.SP1 and 3.1.7.SP1 are now available
-desc: Class defining fixes for Weld 3 and 4
+description: Class defining fixes for Weld 3 and 4
 tags: [release]
 aliases: [/news/2021/04/14/weld-401SP1-317SP1/]
 ---

--- a/content/posts/2021-07-14-weld-402Final-318Final.asciidoc
+++ b/content/posts/2021-07-14-weld-402Final-318Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 4.0.2.Final and 3.1.8.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 4.0.2.Final and 3.1.8.Final are now available
-desc: Maintenance releases for Weld 3 and 4
+description: Maintenance releases for Weld 3 and 4
 tags: [release]
 aliases: [/news/2021/07/14/weld-402Final-318Final/]
 ---

--- a/content/posts/2022-01-24-weld-500Beta1.asciidoc
+++ b/content/posts/2022-01-24-weld-500Beta1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.0.0.Beta1
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 5.0.0.Beta1
-desc: Weld 5.0.0.Beta1 is now available
+description: Weld 5.0.0.Beta1 is now available
 tags: [release]
 aliases: [/news/2022/01/24/weld-500Beta1/]
 ---

--- a/content/posts/2022-02-16-weld-403Final-319Final.asciidoc
+++ b/content/posts/2022-02-16-weld-403Final-319Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 4.0.3.Final and 3.1.9.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 4.0.3.Final and 3.1.9.Final are now available
-desc: Updated versions of Weld 3 and 4
+description: Updated versions of Weld 3 and 4
 tags: [release]
 aliases: [/news/2022/02/16/weld-403Final-319Final/]
 ---

--- a/content/posts/2022-02-23-weld-500CR1.asciidoc
+++ b/content/posts/2022-02-23-weld-500CR1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.0.0.CR1
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 5.0.0.CR1
-desc: Weld 5.0.0.CR1 has arrived
+description: Weld 5.0.0.CR1 has arrived
 tags: [release]
 aliases: [/news/2022/02/23/weld-500CR1/]
 ---

--- a/content/posts/2022-03-23-weld-500CR2.asciidoc
+++ b/content/posts/2022-03-23-weld-500CR2.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.0.0.CR2
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 5.0.0.CR2
-desc: Weld 5 Candidate Release, Round 2
+description: Weld 5 Candidate Release, Round 2
 tags: [release]
 aliases: [/news/2022/03/23/weld-500CR2/]
 ---

--- a/content/posts/2022-04-29-weld-500Final.asciidoc
+++ b/content/posts/2022-04-29-weld-500Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.0.0.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Finally, Weld 5 Final is here!
-desc: Finally, Weld 5 Final is here!
+description: Finally, Weld 5 Final is here!
 tags: [release]
 aliases: [/news/2022/04/29/weld-500Final/]
 ---

--- a/content/posts/2022-05-04-weld-500SP1.asciidoc
+++ b/content/posts/2022-05-04-weld-500SP1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.0.0.SP1
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Service release for Weld 5 Final
-desc: Service release for Weld 5 Final
+description: Service release for Weld 5 Final
 tags: [release]
 aliases: [/news/2022/05/04/weld-500SP1/]
 ---

--- a/content/posts/2022-06-08-weld-500SP2.asciidoc
+++ b/content/posts/2022-06-08-weld-500SP2.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.0.0.SP2
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Squashing some more bugs in Weld 5
-desc: Squashing some more bugs in Weld 5
+description: Squashing some more bugs in Weld 5
 tags: [release]
 aliases: [/news/2022/06/08/weld-500SP2/]
 ---

--- a/content/posts/2022-06-24-weld-501Final.asciidoc
+++ b/content/posts/2022-06-24-weld-501Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.0.1.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 5.0.1.Final coming your way!
-desc: Weld 5.0.1.Final coming your way!
+description: Weld 5.0.1.Final coming your way!
 tags: [release]
 aliases: [/news/2022/06/24/weld-501Final/]
 ---

--- a/content/posts/2022-10-03-weld-510Final.asciidoc
+++ b/content/posts/2022-10-03-weld-510Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.1.0.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 5.1 and dropping Weld Probe
-desc: Weld 5.1.0.Final is now available
+description: Weld 5.1.0.Final is now available
 tags: [release]
 aliases: [/news/2022/10/03/weld-510Final/]
 ---

--- a/content/posts/2023-06-12-weld-511Final.asciidoc
+++ b/content/posts/2023-06-12-weld-511Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.1.1.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 5.1.1.Final released!
-desc: Weld 5.1.1.Final released!
+description: Weld 5.1.1.Final released!
 tags: [release]
 aliases: [/news/2023/06/12/weld-511Final/]
 ---

--- a/content/posts/2023-07-11-weld-511SP1.asciidoc
+++ b/content/posts/2023-07-11-weld-511SP1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.1.1.SP1
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 5.1.1.SP1 available
-desc: Weld 5.1.1.SP1 available
+description: Weld 5.1.1.SP1 available
 tags: [release]
 aliases: [/news/2023/07/11/weld-511SP1/]
 ---

--- a/content/posts/2023-08-09-weld-511SP2.asciidoc
+++ b/content/posts/2023-08-09-weld-511SP2.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.1.1.SP2
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 5.1.1.SP2 available
-desc: Weld 5.1.1.SP2 available
+description: Weld 5.1.1.SP2 available
 tags: [release]
 aliases: [/news/2023/08/09/weld-511SP2/]
 ---

--- a/content/posts/2023-10-05-weld-512Final.asciidoc
+++ b/content/posts/2023-10-05-weld-512Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.1.2.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 5.1.2.Final is now available
-desc: Weld 5.1.2.Final is now available
+description: Weld 5.1.2.Final is now available
 tags: [release]
 aliases: [/news/2023/10/05/weld-512Final/]
 ---

--- a/content/posts/2023-10-26-weld-600Alpha1.asciidoc
+++ b/content/posts/2023-10-26-weld-600Alpha1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 6.0.0.Alpha1
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 6.0.0.Alpha1 is now available
-desc: Weld 6.0.0.Alpha1 is now available
+description: Weld 6.0.0.Alpha1 is now available
 tags: [release]
 aliases: [/news/2023/10/26/weld-600Alpha1/]
 ---

--- a/content/posts/2024-02-26-weld-600Beta1.asciidoc
+++ b/content/posts/2024-02-26-weld-600Beta1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 6.0.0.Beta1
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 6.0.0.Beta1 is now available
-desc: Weld 6.0.0.Beta1 is now available
+description: Weld 6.0.0.Beta1 is now available
 tags: [release]
 aliases: [/news/2024/02/26/weld-600Beta1/]
 ---

--- a/content/posts/2024-07-03-weld-600Beta4.asciidoc
+++ b/content/posts/2024-07-03-weld-600Beta4.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 6.0.0.Beta4
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 6.0.0.Beta4 is now available
-desc: Weld 6.0.0.Beta4 is now available
+description: Weld 6.0.0.Beta4 is now available
 tags: [release]
 aliases: [/news/2024/07/03/weld-600Beta4/]
 ---

--- a/content/posts/2024-08-27-weld-513Final.asciidoc
+++ b/content/posts/2024-08-27-weld-513Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.1.3.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Squashing bugs with Weld 5.1.3.Final!
-desc: Squashing bugs with Weld 5.1.3.Final!
+description: Squashing bugs with Weld 5.1.3.Final!
 tags: [release]
 aliases: [/news/2024/08/27/weld-513Final/]
 ---

--- a/content/posts/2024-11-13-weld-600CR1.asciidoc
+++ b/content/posts/2024-11-13-weld-600CR1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 6.0.0.CR1
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 6.0.0.CR1 is now available
-desc: Weld 6.0.0.CR1 is now available
+description: Weld 6.0.0.CR1 is now available
 tags: [release]
 aliases: [/news/2024/11/13/weld-600CR1/]
 ---

--- a/content/posts/2024-11-28-weld-600CR2.asciidoc
+++ b/content/posts/2024-11-28-weld-600CR2.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 6.0.0.CR2
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 6.0.0.CR2 is now available
-desc: Weld 6.0.0.CR2 is now available
+description: Weld 6.0.0.CR2 is now available
 tags: [release]
 aliases: [/news/2024/11/28/weld-600CR2/]
 ---

--- a/content/posts/2024-12-16-weld-514Final.asciidoc
+++ b/content/posts/2024-12-16-weld-514Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.1.4.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Tiny update for Weld 5.1
-desc: Tiny update for Weld 5.1
+description: Tiny update for Weld 5.1
 tags: [release]
 aliases: [/news/2024/12/16/weld-514Final/]
 ---

--- a/content/posts/2024-12-16-weld-600Final.asciidoc
+++ b/content/posts/2024-12-16-weld-600Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 6.0.0.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 6.0.0.Final released
-desc: Weld 6.0.0.Final released
+description: Weld 6.0.0.Final released
 tags: [release]
 aliases: [/news/2024/12/16/weld-600Final/]
 ---

--- a/content/posts/2025-01-21-weld-515Final.asciidoc
+++ b/content/posts/2025-01-21-weld-515Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.1.5.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Another small update for Weld 5.1
-desc: Another small update for Weld 5.1
+description: Another small update for Weld 5.1
 tags: [release]
 aliases: [/news/2025/01/21/weld-515Final/]
 ---

--- a/content/posts/2025-02-18-weld-601Final.asciidoc
+++ b/content/posts/2025-02-18-weld-601Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 6.0.1.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: First update for Weld 6
-desc: First update for Weld 6
+description: First update for Weld 6
 tags: [release]
 aliases: [/news/2025/02/18/weld-601Final/]
 ---

--- a/content/posts/2025-03-27-middleware-strategy.asciidoc
+++ b/content/posts/2025-03-27-middleware-strategy.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Red Hat Middleware Strategy
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
 tags: [team]
 aliases: [/news/2025/03/27/middleware-strategy/]
 ---

--- a/content/posts/2025-04-03-weld-602Final.asciidoc
+++ b/content/posts/2025-04-03-weld-602Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 6.0.2.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Weld 6.0.2.Final is now available
-desc: Weld 6.0.2.Final is now available
+description: Weld 6.0.2.Final is now available
 tags: [release]
 aliases: [/news/2025/04/03/weld-602Final/]
 ---

--- a/content/posts/2025-05-07-weld-to-foundation.asciidoc
+++ b/content/posts/2025-05-07-weld-to-foundation.asciidoc
@@ -2,8 +2,6 @@
 layout: post
 title: Moving to a Foundation
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
 tags: [team]
 aliases: [/news/2025/05/07/weld-to-foundation/]
 ---

--- a/content/posts/2025-05-20-weld-516Final.asciidoc
+++ b/content/posts/2025-05-20-weld-516Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.1.6.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Minor bugfix for Weld 5.1
-desc: Minor bugfix for Weld 5.1
+description: Minor bugfix for Weld 5.1
 tags: [release]
 aliases: [/news/2025/05/20/weld-516Final/]
 ---

--- a/content/posts/2025-05-20-weld-603Final.asciidoc
+++ b/content/posts/2025-05-20-weld-603Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 6.0.3.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Minor bugfix for Weld 6
-desc: Minor bugfix for Weld 6
+description: Minor bugfix for Weld 6
 tags: [release]
 aliases: [/news/2025/05/20/weld-603Final/]
 ---

--- a/content/posts/2025-12-01-weld-700Alpha1.asciidoc
+++ b/content/posts/2025-12-01-weld-700Alpha1.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 7.0.0.Alpha1
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: First release of Weld 7
-desc: First release of Weld 7
+description: First release of Weld 7
 tags: [release]
 aliases: [/news/2025/12/01/weld-700Alpha1/]
 ---

--- a/content/posts/2026-01-14-weld-517Final.asciidoc
+++ b/content/posts/2026-01-14-weld-517Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 5.1.7.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Minor update for Weld 5
-desc: Minor update for Weld 5
+description: Minor update for Weld 5
 tags: [release]
 aliases: [/news/2026/01/14/weld-517Final/]
 ---

--- a/content/posts/2026-01-14-weld-604Final.asciidoc
+++ b/content/posts/2026-01-14-weld-604Final.asciidoc
@@ -2,10 +2,7 @@
 layout: post
 title: Weld 6.0.4.Final
 author: Matej Novotny
-priority: 1
-change_frequency: weekly
-excerpt: Minor bugfix for Weld 6
-desc: Minor bugfix for Weld 6
+description: Minor bugfix for Weld 6
 tags: [release]
 aliases: [/news/2026/01/14/weld-604Final/]
 ---

--- a/content/posts/2026-05-27-weld-700Beta1.asciidoc
+++ b/content/posts/2026-05-27-weld-700Beta1.asciidoc
@@ -1,0 +1,42 @@
+---
+layout: post
+title: Weld 7.0.0.Beta1
+author: Matej Novotny
+description: Weld 7.0.0.Beta1 — feature complete CDI 5.0 implementation
+tags: [release]
+---
+:linkattrs:
+
+Weld Core 7.0.0.Beta1 and Weld API 7.0.Beta1 have landed in Maven Central. +
+This is a *feature complete* implementation of Jakarta CDI 5.0.Beta1!
+
+Since the link:/posts/weld-7-0-0-alpha1/[Alpha1 release], the remaining CDI 5.0 features have been implemented (link:https://redhat.atlassian.net/browse/WELD-2835[WELD-2835], link:https://redhat.atlassian.net/browse/WELD-2836[WELD-2836]):
+
+* `@Eager` annotation for eager initialization of `@ApplicationScoped` beans — the CDI equivalent of EJB's `@Startup`
+* `@AutoClose` annotation — beans implementing `AutoCloseable` are now automatically closed during destruction without the need for explicit `@PreDestroy` or `@Disposes` methods
+* Asynchronous method invokers via the new `AsyncHandler` API
+* Programmatic registration of `BuildCompatibleExtension` in CDI SE
+* `SyntheticInjections` for injection points in synthetic beans
+* Global scopes — application scope is now global
+* Support for parameterized types in `@Registration`
+* Removal of deprecated EL-related `BeanManager` methods (moved to `ELAwareBeanManager` in CDI 4.1)
+* Removal of `SecurityManager` references
+
+Other enhancements and bug fixes in this release:
+
+* Trimming a non-explicit bean archive is now correctly treated as a deployment problem (link:https://redhat.atlassian.net/browse/WELD-2832[WELD-2832])
+* Optimized how Weld keeps references to dependent instances within `CreationalContext` (link:https://redhat.atlassian.net/browse/WELD-2834[WELD-2834])
+* Fixed `ClassCastException` when unwrapping proxied `EntityManager` (link:https://redhat.atlassian.net/browse/WELD-2245[WELD-2245])
+* Fixed reflection discovery strategy incorrectly discovering beans with just inherited BDA in SE (link:https://redhat.atlassian.net/browse/WELD-2826[WELD-2826])
+* Startup event is now fired in a synchronized block (link:https://redhat.atlassian.net/browse/WELD-2827[WELD-2827])
+* Ensured proxy target JPMS modules can read Weld JPMS modules (link:https://redhat.atlassian.net/browse/WELD-2828[WELD-2828])
+* `ProcessSyntheticAnnotatedType` now correctly fired for types added via configurators (link:https://redhat.atlassian.net/browse/WELD-2831[WELD-2831])
+* `Weld#addExtensions` no longer swallows exceptions (link:https://redhat.atlassian.net/browse/WELD-2833[WELD-2833])
+
+For the full list of what's new in CDI 5.0, see the link:https://jakarta.ee/specifications/cdi/5.0/[Jakarta CDI 5.0 specification page].
+
+As always, if you find any issues, don't hesitate to reach out!
+
+&#91; link:/download/[Download] &#93;
+&#91; link:https://docs.jboss.org/weld/reference/7.0.0.Beta1/en-US/html_single/[Documentation, window="_blank"] &#93;
+&#91; link:https://github.com/weld/core/releases/tag/7.0.0.Beta1[Release, window="_blank"] &#93;


### PR DESCRIPTION
Release announcement post for Weld 7.0.0.Beta1.

Also includes two small fixes:
- Rename `desc` to `description` in old post frontmatter so RSS feed entries are no longer empty
- Update README to document `description` and `tags` frontmatter fields