### PR TITLE
Website polish: contribute rework, dependabot, CSS cleanup, image fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/content/contribute.md
+++ b/content/contribute.md
@@ -5,28 +5,155 @@ title: Contribute
 
 # Contribute
 
-Weld is open source and we welcome contributions from the community.
+There are many ways to get involved with Weld. Here you'll find everything you need
+to contribute, report issues, or connect with the team.
+
+## Get Involved
+
+<div class="row g-4 mb-5">
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-comments text-primary"></i> Discussions
+        </h3>
+        <p class="card-text">
+          The place to ask questions, discuss ideas, and get help from other Weld users
+          and maintainers.
+        </p>
+        <a href="https://github.com/weld/core/discussions" class="btn btn-outline-primary" target="_blank">
+          Join Discussions <i class="fas fa-arrow-right"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-bug text-danger"></i> Issue Tracker
+        </h3>
+        <p class="card-text">
+          Found a bug or have a feature request? Weld Core, API, and Parent use JIRA.
+          Other projects like Weld Testing use GitHub Issues.
+        </p>
+        <a href="https://issues.redhat.com/projects/WELD/issues/" class="btn btn-outline-primary me-2" target="_blank">
+          JIRA <i class="fas fa-arrow-right"></i>
+        </a>
+        <a href="https://github.com/weld/weld-testing/issues" class="btn btn-outline-secondary" target="_blank">
+          Weld Testing <i class="fab fa-github"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-code-branch text-success"></i> Contributing
+        </h3>
+        <p class="card-text">
+          Everything you need to know before submitting a pull request — building,
+          testing, formatting, and PR guidelines.
+        </p>
+        <a href="https://github.com/weld/.github/blob/main/CONTRIBUTING.md" class="btn btn-outline-primary" target="_blank">
+          Contributing Guide <i class="fas fa-arrow-right"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-envelope text-info"></i> Mailing List
+        </h3>
+        <p class="card-text">
+          Historically used for development discussions. Still monitored, but GitHub
+          Discussions is now the primary channel for reaching the team.
+        </p>
+        <a href="https://lists.jboss.org/archives/list/weld-dev@lists.jboss.org/" class="btn btn-outline-primary" target="_blank">
+          Browse Archives <i class="fas fa-arrow-right"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
 
 ## Source Code
 
-- [weld/core](https://github.com/weld/core) — Weld Core Implementation
-- [weld/api](https://github.com/weld/api) — Weld API
-- [weld/weld-testing](https://github.com/weld/weld-testing) — JUnit 5 Extensions for CDI Testing
+<div class="row g-4 mb-5">
+  <div class="col-md-6 col-lg-3">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fab fa-github"></i> Weld Core
+        </h3>
+        <p class="card-text">
+          The CDI reference implementation.
+        </p>
+        <a href="https://github.com/weld/core" class="btn btn-outline-secondary" target="_blank">
+          View on GitHub <i class="fas fa-external-link-alt"></i>
+        </a>
+      </div>
+    </div>
+  </div>
 
-## How to Contribute
+  <div class="col-md-6 col-lg-3">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fab fa-github"></i> Weld API
+        </h3>
+        <p class="card-text">
+          Weld-specific API extensions.
+        </p>
+        <a href="https://github.com/weld/api" class="btn btn-outline-secondary" target="_blank">
+          View on GitHub <i class="fas fa-external-link-alt"></i>
+        </a>
+      </div>
+    </div>
+  </div>
 
-1. Fork the repository on GitHub
-2. Create a branch for your changes
-3. Submit a pull request
+  <div class="col-md-6 col-lg-3">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fab fa-github"></i> Weld Testing
+        </h3>
+        <p class="card-text">
+          JUnit 5 extensions for CDI testing.
+        </p>
+        <a href="https://github.com/weld/weld-testing" class="btn btn-outline-secondary" target="_blank">
+          View on GitHub <i class="fas fa-external-link-alt"></i>
+        </a>
+      </div>
+    </div>
+  </div>
 
-For build instructions and development setup, see the README in each repository.
+  <div class="col-md-6 col-lg-3">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fab fa-github"></i> Weld Parent
+        </h3>
+        <p class="card-text">
+          Parent POM with shared configuration.
+        </p>
+        <a href="https://github.com/weld/parent" class="btn btn-outline-secondary" target="_blank">
+          View on GitHub <i class="fas fa-external-link-alt"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
 
 ## Reporting Bugs
 
-The [issue tracker](https://issues.redhat.com/browse/WELD) is where all Weld bugs,
-feature requests and enhancement requests reside.
-
-When filing a bug, please:
+When filing a bug, whether on [JIRA](https://issues.redhat.com/projects/WELD/issues/) or GitHub Issues, please:
 
 1. **Browse existing issues** before creating a new one to avoid duplicates
 2. **Create one issue per bug** — keep each issue focused and trackable
@@ -36,10 +163,79 @@ When filing a bug, please:
 6. **Provide a reproducer** if possible — a minimal example showing the bug speeds
    up the fix significantly
 
-## Contact
+## Contributors
 
-- **Mailing list:** [weld-dev](https://lists.jboss.org/mailman/listinfo/weld-dev)
-  — for development discussions and announcements
-- **GitHub:** [github.com/weld](https://github.com/weld) — source code and pull requests
-- **Issue tracker:** [JIRA](https://issues.redhat.com/browse/WELD) — bug reports
-  and feature requests
+<div class="row g-4 mb-5">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-users text-primary"></i> Meet the Team
+        </h3>
+        <p class="card-text">
+          Weld is built by a community of contributors. See all the people who have
+          helped make Weld what it is today.
+        </p>
+        <a href="https://github.com/weld/core/graphs/contributors" class="btn btn-outline-primary" target="_blank">
+          View Contributors <i class="fas fa-external-link-alt"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+## Governance
+
+<div class="row g-4 mb-5">
+  <div class="col-md-4">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-landmark text-primary"></i> Commonhaus Foundation
+        </h3>
+        <p class="card-text">
+          Weld joined the Commonhaus Foundation in 2025, alongside WildFly and other
+          middleware projects. The foundation ensures long-term stewardship of
+          community-driven open source.
+        </p>
+        <a href="https://www.commonhaus.org/" class="btn btn-outline-secondary" target="_blank">
+          Learn More <i class="fas fa-external-link-alt"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-4">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-gavel text-primary"></i> Project Governance
+        </h3>
+        <p class="card-text">
+          See how decisions are made and how you can influence the project's direction
+          through our open governance model.
+        </p>
+        <a href="https://github.com/weld/.github/blob/main/GOVERNANCE.md" class="btn btn-outline-secondary" target="_blank">
+          Governance Document <i class="fas fa-external-link-alt"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-4">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-heart text-danger"></i> Code of Conduct
+        </h3>
+        <p class="card-text">
+          Our community values respect and inclusivity. Please review our community
+          standards.
+        </p>
+        <a href="https://github.com/weld/.github/blob/main/CODE_OF_CONDUCT.md" class="btn btn-outline-secondary" target="_blank">
+          Code of Conduct <i class="fas fa-external-link-alt"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/content/documentation.md
+++ b/content/documentation.md
@@ -387,7 +387,7 @@ See [Weld Reference Guide](https://docs.jboss.org/weld/reference/latest/en-US/ht
 The container initializes the bean instances of normal scoped beans lazily.
 In other words, when injecting an `@ApplicationScoped` bean a new instance is not created until actually used.
 Instead, a shared client proxy is injected.
-See [Weld Tip 3 - Boost performance of Weld apps](https://weld.cdi-spec.org/news/2016/10/25/tip3-performance/#_lazy_initialization_of_bean_instances) for more information.
+See [Weld Tip 3 - Boost performance of Weld apps](/posts/weld-tip-3-boost-performance-of-weld-apps/#_lazy_initialization_of_bean_instances) for more information.
 
 #### Circular Dependencies
 

--- a/public/css/weld-theme.css
+++ b/public/css/weld-theme.css
@@ -116,46 +116,6 @@ a:hover {
   max-height: none !important;
 }
 
-#wrapper,
-#maincontent-wrapper,
-#wrapper-2,
-#wrap-content,
-#wrapper-3,
-#main-wrapper {
-  all: unset !important;
-  display: block !important;
-  width: 100% !important;
-  max-width: none !important;
-  margin: 0 !important;
-  padding: 0 !important;
-  background: none !important;
-  float: none !important;
-  box-shadow: none !important;
-  border-radius: 0 !important;
-  height: auto !important;
-  min-height: 0 !important;
-  overflow: visible !important;
-}
-
-#main {
-  all: unset !important;
-  display: block !important;
-  width: 100% !important;
-  padding: 0 !important;
-  margin: 0 !important;
-  background: white !important;
-  min-height: auto !important;
-  height: auto !important;
-  overflow: visible !important;
-}
-
-/* Hide old logo and branding */
-#branding,
-#logo,
-#proj_logo,
-#proj_logo-neg {
-  display: none !important;
-}
 
 /* ============================================
    HEADER & BANNER
@@ -194,15 +154,6 @@ a:hover {
   }
 }
 
-#projectname {
-  all: unset !important;
-  display: block !important;
-  font-size: 1.5rem !important;
-  font-weight: 700 !important;
-  color: var(--weld-primary-dark) !important;
-  margin: 0.25rem 0 0.125rem 0 !important;
-  letter-spacing: -0.02em !important;
-}
 
 /* ============================================
    NAVIGATION - Bootstrap Navbar Style
@@ -1116,16 +1067,6 @@ table tbody tr:last-child td,
   color: #e6edf3 !important;
 }
 
-[data-bs-theme="dark"] #wrapper,
-[data-bs-theme="dark"] #maincontent-wrapper,
-[data-bs-theme="dark"] #wrapper-2,
-[data-bs-theme="dark"] #wrap-content,
-[data-bs-theme="dark"] #wrapper-3,
-[data-bs-theme="dark"] #main-wrapper,
-[data-bs-theme="dark"] #main {
-  background: #0d1117 !important;
-  color: #e6edf3 !important;
-}
 
 [data-bs-theme="dark"] #top_subnav_branding {
   background: #161b22 !important;

--- a/public/css/weld-theme.css
+++ b/public/css/weld-theme.css
@@ -116,7 +116,6 @@ a:hover {
   max-height: none !important;
 }
 
-
 /* ============================================
    HEADER & BANNER
    ============================================ */
@@ -153,7 +152,6 @@ a:hover {
     overflow: hidden !important;
   }
 }
-
 
 /* ============================================
    NAVIGATION - Bootstrap Navbar Style
@@ -1066,7 +1064,6 @@ table tbody tr:last-child td,
   background-color: #0d1117 !important;
   color: #e6edf3 !important;
 }
-
 
 [data-bs-theme="dark"] #top_subnav_branding {
   background: #161b22 !important;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 site.collections.posts=true
+
+quarkus.asciidoc.attributes.imagesdir=/images/


### PR DESCRIPTION
- Remove dead CSS selectors inherited from RESTEasy theme
- Add Dependabot config for Maven and GitHub Actions dependency updates
- Rework Contribute page with card-based layout, governance section, and updated content
- Configure global `imagesdir` for AsciiDoc posts (fixes missing images in old posts)
- Fix self-referencing absolute URL in documentation FAQ to use relative path