### PR TITLE
Redesign Documentation page layout

### DIFF
--- a/content/documentation.md
+++ b/content/documentation.md
@@ -7,44 +7,191 @@ title: Documentation
 
 ## Reference Documentation
 
-### Weld 7 (CDI 5.0)
+<div class="row g-4 mb-5">
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-book text-primary"></i> Weld 7
+          <span class="doc-badge-latest">Latest</span>
+        </h3>
+        <p class="card-text">Reference implementation of CDI 5.0</p>
+        <span class="doc-card-group-label">Weld Reference</span>
+        <div class="mb-2">
+          <a href="https://docs.jboss.org/weld/reference/latest/en-US/html_single/" class="btn btn-outline-primary btn-sm me-1" target="_blank" rel="noopener noreferrer">
+            HTML Docs <i class="fas fa-arrow-right"></i>
+          </a>
+          <a href="https://docs.jboss.org/weld/reference/latest/en-US/pdf/weld-reference.pdf" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener noreferrer">
+            PDF <i class="fas fa-arrow-right"></i>
+          </a>
+        </div>
+        <span class="doc-card-group-label">CDI Specification</span>
+        <div>
+          <a href="https://jakarta.ee/specifications/cdi/5.0/jakarta-cdi-spec-5.0" class="btn btn-outline-secondary btn-sm me-1" target="_blank" rel="noopener noreferrer">
+            CDI 5.0 Spec <i class="fas fa-arrow-right"></i>
+          </a>
+          <a href="https://jakartaee.github.io/cdi/2026/06/05/whats-new-in-cdi50.html" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener noreferrer">
+            What's New in CDI 5.0 <i class="fas fa-arrow-right"></i>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
 
-- [HTML (Single page)](https://docs.jboss.org/weld/reference/latest/en-US/html_single/)
-- [PDF](https://docs.jboss.org/weld/reference/latest/en-US/pdf/weld-reference.pdf)
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-book text-primary"></i> Weld 6
+        </h3>
+        <p class="card-text">Reference implementation of CDI 4.1</p>
+        <span class="doc-card-group-label">Weld Reference</span>
+        <div class="mb-2">
+          <a href="https://docs.jboss.org/weld/reference/latest-6.0/en-US/html_single/" class="btn btn-outline-primary btn-sm me-1" target="_blank" rel="noopener noreferrer">
+            HTML Docs <i class="fas fa-arrow-right"></i>
+          </a>
+          <a href="https://docs.jboss.org/weld/reference/latest-6.0/en-US/pdf/weld-reference.pdf" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener noreferrer">
+            PDF <i class="fas fa-arrow-right"></i>
+          </a>
+        </div>
+        <span class="doc-card-group-label">CDI Specification</span>
+        <div>
+          <a href="https://jakarta.ee/specifications/cdi/4.1/jakarta-cdi-spec-4.1" class="btn btn-outline-secondary btn-sm me-1" target="_blank" rel="noopener noreferrer">
+            CDI 4.1 Spec <i class="fas fa-arrow-right"></i>
+          </a>
+          <a href="https://jakartaee.github.io/cdi/2024/02/27/whats-new-in-cdi41.html" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener noreferrer">
+            What's New in CDI 4.1 <i class="fas fa-arrow-right"></i>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
 
-### Weld 6 (CDI 4.1)
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-book text-primary"></i> Weld 5
+        </h3>
+        <p class="card-text">Reference implementation of CDI 4.0</p>
+        <span class="doc-card-group-label">Weld Reference</span>
+        <div class="mb-2">
+          <a href="https://docs.jboss.org/weld/reference/latest-5.1/en-US/html_single/" class="btn btn-outline-primary btn-sm me-1" target="_blank" rel="noopener noreferrer">
+            HTML Docs <i class="fas fa-arrow-right"></i>
+          </a>
+          <a href="https://docs.jboss.org/weld/reference/latest-5.1/en-US/pdf/weld-reference.pdf" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener noreferrer">
+            PDF <i class="fas fa-arrow-right"></i>
+          </a>
+        </div>
+        <span class="doc-card-group-label">CDI Specification</span>
+        <div>
+          <a href="https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0" class="btn btn-outline-secondary btn-sm me-1" target="_blank" rel="noopener noreferrer">
+            CDI 4.0 Spec <i class="fas fa-arrow-right"></i>
+          </a>
+          <a href="https://jakartaee.github.io/cdi/2021/10/25/way-to-cdi4.html" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener noreferrer">
+            Way to CDI 4.0 <i class="fas fa-arrow-right"></i>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
 
-- [HTML (Single page)](https://docs.jboss.org/weld/reference/latest-6.0/en-US/html_single/)
-- [PDF](https://docs.jboss.org/weld/reference/latest-6.0/en-US/pdf/weld-reference.pdf)
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-book text-primary"></i> Weld 4
+        </h3>
+        <p class="card-text">Reference implementation of CDI 3.0</p>
+        <span class="doc-card-group-label">Weld Reference</span>
+        <div class="mb-2">
+          <a href="https://docs.jboss.org/weld/reference/latest-4.0/en-US/html_single/" class="btn btn-outline-primary btn-sm me-1" target="_blank" rel="noopener noreferrer">
+            HTML Docs <i class="fas fa-arrow-right"></i>
+          </a>
+          <a href="https://docs.jboss.org/weld/reference/latest-4.0/en-US/pdf/weld-reference.pdf" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener noreferrer">
+            PDF <i class="fas fa-arrow-right"></i>
+          </a>
+        </div>
+        <span class="doc-card-group-label">CDI Specification</span>
+        <div>
+          <a href="https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener noreferrer">
+            CDI 3.0 Spec <i class="fas fa-arrow-right"></i>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
 
-### Weld 5 (CDI 4.0)
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-body">
+        <h3 class="card-title">
+          <i class="fas fa-book text-primary"></i> Weld 3
+        </h3>
+        <p class="card-text">Reference implementation of CDI 2.0</p>
+        <span class="doc-card-group-label">Weld Reference</span>
+        <div class="mb-2">
+          <a href="https://docs.jboss.org/weld/reference/latest-3.1/en-US/html_single/" class="btn btn-outline-primary btn-sm me-1" target="_blank" rel="noopener noreferrer">
+            HTML Docs <i class="fas fa-arrow-right"></i>
+          </a>
+          <a href="https://docs.jboss.org/weld/reference/latest-3.1/en-US/pdf/weld-reference.pdf" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener noreferrer">
+            PDF <i class="fas fa-arrow-right"></i>
+          </a>
+        </div>
+        <span class="doc-card-group-label">CDI Specification</span>
+        <div>
+          <a href="https://jakarta.ee/specifications/cdi/2.0/cdi-spec-2.0" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener noreferrer">
+            CDI 2.0 Spec <i class="fas fa-arrow-right"></i>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
 
-- [HTML (Single page)](https://docs.jboss.org/weld/reference/latest-5.1/en-US/html_single/)
-- [PDF](https://docs.jboss.org/weld/reference/latest-5.1/en-US/pdf/weld-reference.pdf)
-
-### Weld 4 (CDI 3.0)
-
-- [HTML (Single page)](https://docs.jboss.org/weld/reference/latest-4.0/en-US/html_single/)
-- [PDF](https://docs.jboss.org/weld/reference/latest-4.0/en-US/pdf/weld-reference.pdf)
-
-### Weld 3 (CDI 2.0)
-
-- [HTML (Single page)](https://docs.jboss.org/weld/reference/latest-3.1/en-US/html_single/)
-- [PDF](https://docs.jboss.org/weld/reference/latest-3.1/en-US/pdf/weld-reference.pdf)
-
-[Browse documentation for older Weld releases](https://docs.jboss.org/weld/reference/)
+  <div class="col-md-6">
+    <div class="card h-100 doc-older-releases-card">
+      <div class="card-body d-flex flex-column align-items-center justify-content-center text-center">
+        <h3 class="card-title">
+          <i class="fas fa-clock-rotate-left text-muted"></i> Weld Archives
+        </h3>
+        <p class="card-text">Looking for an older version of Weld?</p>
+        <a href="https://docs.jboss.org/weld/reference/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener noreferrer">
+          Browse Older Releases <i class="fas fa-external-link-alt"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
 
 ---
 
 ## Frequently Asked Questions
 
-### If I create a thread in my CDI bean, how will Weld react?
+<div class="accordion doc-accordion" id="faqAccordion">
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq1" aria-expanded="false" aria-controls="faq1">
+        If I create a thread in my CDI bean, how will Weld react?
+      </button>
+    </h3>
+    <div id="faq1" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 Weld assumes requests are single threaded, and uses thread locals to isolate requests. This means that if user created threads are used then built in implementation of the session scope, the request scope and the conversation scope, will become dissociated, and you will find they are no longer active in the new thread, nor able to access their contextual data. The Weld [reference guide](https://docs.jboss.org/weld/reference/latest/en-US/html/contexts.html) contains information on how to associate a request to a context and activate it. Doing this in your new thread will cause the contexts to be active, and contain the same contextual data.
 
 The dependent context and the application context will work as usual in any user created thread.
 
-### Why does Weld leave some proxy class definitions lying around when I undeploy my application? How can I prevent this?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq2" aria-expanded="false" aria-controls="faq2">
+        Why does Weld leave some proxy class definitions lying around when I undeploy my application? How can I prevent this?
+      </button>
+    </h3>
+    <div id="faq2" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 When a Weld-enabled application is deployed on an application server or a web server, proxy classes for beans implementing interfaces or extending classes contained in common libraries are loaded in the class loader (CL) for that library, not the thread context class loader (TCCL). This means that these proxy classes will not be removed from the server when the application is undeployed.
 
@@ -52,7 +199,16 @@ The reason for this approach is to support the use of package scoped classes and
 
 One way to prevent this problem is to simply deploy those libraries with your application. In this scenario, those classes are loaded in a CL associated with the application and will thus be removed when the application is undeployed.
 
-### Some of my beans aren't deployed and I can't see why?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq3" aria-expanded="false" aria-controls="faq3">
+        Some of my beans aren't deployed and I can't see why?
+      </button>
+    </h3>
+    <div id="faq3" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 Weld will not create beans if it can't load the class, or some class dependency. If that happens, you'll see a note in the server log.
 
@@ -62,7 +218,16 @@ WELD-000119: Not generating any bean definitions from org.jboss.weld.tests.beanD
 
 You can view more details by increasing the log level of the application server to DEBUG.
 
-### Why does Weld set character encoding of an HTTP request/response body to ISO-8859-1?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq4" aria-expanded="false" aria-controls="faq4">
+        Why does Weld set character encoding of an HTTP request/response body to ISO-8859-1?
+      </button>
+    </h3>
+    <div id="faq4" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 **Update**: Since Weld 2.2 the conversation context is activated lazily and this problem does not occur.
 If you are using an older version of Weld or need the conversation context to be activated eagerly, read further.
@@ -99,7 +264,16 @@ A workaround is to have the application encoding-setting filter to be called bef
 </web-app>  
 ```
 
-### My application bundles a third-party library which uses javax.inject annotations. This library was not intended to be a CDI library but on CDI 1.1 this library is being picked up as an implicit bean archive and breaks the deployment of my application. Why is this happening?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq5" aria-expanded="false" aria-controls="faq5">
+        My application bundles a third-party library which uses javax.inject annotations. This library was not intended to be a CDI library but on CDI 1.1 this library is being picked up as an implicit bean archive and breaks the deployment of my application. Why is this happening?
+      </button>
+    </h3>
+    <div id="faq5" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 Firstly, this issue only affects CDI 1.1. If possible, go and upgrade to CDI 1.2 (Weld 2.2 or later) where this issue does not occur.
 
@@ -108,7 +282,7 @@ This is a [known issue](https://issues.jboss.org/browse/CDI-377) in the CDI 1.1 
 
 A workaround is to configure the application server to require the `beans.xml` file in bean archives (suppress implicit bean archives). The way to configure this varies across application servers:
 
-**GlassFish 4**
+#### GlassFish 4
 
 global configuration:
 ```
@@ -119,7 +293,7 @@ per-deployment configuration:
 asadmin deploy --property implicitCdiEnabled=false <archive>
 ```
 
-**WildFly 8**
+#### WildFly 8
 
 global configuration:
 ```
@@ -132,7 +306,16 @@ per-deployment configuration - add the following content to `META-INF/jboss-all.
 </jboss>
 ```
 
-### How can I bundle my entire SE application with Weld into a single jar?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq6" aria-expanded="false" aria-controls="faq6">
+        How can I bundle my entire SE application with Weld into a single jar?
+      </button>
+    </h3>
+    <div id="faq6" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 Weld internal classes are not intended to be used in a CDI deployment. As a result, you may [encounter validation errors](https://issues.jboss.org/browse/WELD-1129) when packaging your application together with Weld in a single fat jar file.
 
@@ -149,7 +332,16 @@ A workaround is to exclude Weld classes from bean scanning:
 </beans>
 ```
 
-### I use the Instance API to obtain bean instances. Why does it seem to cause a memory leak?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq7" aria-expanded="false" aria-controls="faq7">
+        I use the Instance API to obtain bean instances. Why does it seem to cause a memory leak?
+      </button>
+    </h3>
+    <div id="faq7" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 The `Instance` API is often used in loops to obtain multiple instances of a certain bean. Here is an example:
 
@@ -167,7 +359,16 @@ The `Instance` API is often used in loops to obtain multiple instances of a cert
 By default, each object obtained using `Instance` remains managed (is not released) until the `Instance` object is destroyed. This can easily create a memory leak.
 Therefore, the application should explicitly destroy obtained instances when it no longer needs by calling the [Instance.destroy()](https://docs.jboss.org/cdi/api/1.1/javax/enterprise/inject/Instance.html#destroy(T)) method.
 
-### How do I enable debug logging for Weld in a specific container?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq8" aria-expanded="false" aria-controls="faq8">
+        How do I enable debug logging for Weld in a specific container?
+      </button>
+    </h3>
+    <div id="faq8" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 When things do not work as expected, more information might be helpful in solving the problem.
 For this reason, you might want to enable the debug (fine) log level for Weld.
@@ -227,7 +428,16 @@ org.jboss.weld.level=FINE
 
 For enabling debug logging on Jetty, see [Jetty Logging](https://www.eclipse.org/jetty/documentation/current/configuring-logging.html)
 
-### What do WELD-000225, WELD-000335 and WELD-000715 warnings mean?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq9" aria-expanded="false" aria-controls="faq9">
+        What do WELD-000225, WELD-000335 and WELD-000715 warnings mean?
+      </button>
+    </h3>
+    <div id="faq9" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 When running on Tomcat with asynchronous Servlets you may observe the following warnings:
 
@@ -245,7 +455,16 @@ correctly in asynchronous Servlet requests. As a result, these warnings are obse
 bean instances properly at the end of a request. See the [Tomcat bug report](https://issues.apache.org/bugzilla/show_bug.cgi?id=57314)
 for more details.
 
-### What is the relation between Weld, CDI and Java EE versions?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq10" aria-expanded="false" aria-controls="faq10">
+        What is the relation between Weld, CDI and Java EE versions?
+      </button>
+    </h3>
+    <div id="faq10" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 Weld versions do not match CDI versioning.
 An overview is provided in the following table:
@@ -259,7 +478,16 @@ An overview is provided in the following table:
 | 2.4 | 1.2 | 7+ | 7 | In maintenance mode. Support available with [JBoss EAP 7.1](https://developers.redhat.com/products/eap/overview/) |
 | 3.0 | 2.0 | 8+ | 8 | Actively developed and stable version of Weld. |
 
-### How do I enable debug logging for Weld SE?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq11" aria-expanded="false" aria-controls="faq11">
+        How do I enable debug logging for Weld SE?
+      </button>
+    </h3>
+    <div id="faq11" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 In Weld 2.1 [SLF4J](https://www.slf4j.org) was replaced with [JBoss Logging](https://developer.jboss.org/wiki/JBossLoggingTooling) which provides support for the internationalization and localization of log messages and exception messages. However, JBoss Logging itself does not write any log messages. Instead, it only constructs a log message and delegates to one of the supported logging frameworks. And so if you want to enable the debug logging for Weld SE, you'll have to **identify** and **configure** the underlying logging framework.
 
@@ -291,7 +519,16 @@ If you just want to see the debug log messages as quickly as possible try to add
 mvn clean test -Dtest=MyWeldSETest -Dorg.jboss.logging.provider=slf4j -Dorg.slf4j.simpleLogger.log.org.jboss.weld=debug
 ```
 
-### How to deploy a Weld application to a Jetty standalone instance?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq12" aria-expanded="false" aria-controls="faq12">
+        How to deploy a Weld application to a Jetty standalone instance?
+      </button>
+    </h3>
+    <div id="faq12" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 You should not experience any classloading issues when starting Jetty as an embedded webapp server from within another Java program. However, if you're using a Jetty standalone instance the deployment with bundled Weld Servlet integration will probably fail and you may observe a similar message in the log:
 
@@ -334,7 +571,16 @@ However, note that if you want to deploy application using CDI along with JSF (e
 * JSF IMPL
 * [Weld Core JSF](https://search.maven.org/#search|ga|1|weld-core-jsf)
 
-### How to patch WildFly with newer Weld version?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq13" aria-expanded="false" aria-controls="faq13">
+        How to patch WildFly with newer Weld version?
+      </button>
+    </h3>
+    <div id="faq13" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 Each version of WildFly is shipped with given version of Weld.
 However, for every Weld release we also prepare a patch for WildFly which allows you to easily upgrade Weld version.
@@ -362,7 +608,16 @@ $>/{$WILDFLY_FOLDER}/bin/jboss-cli.bat|sh --command="patch apply /path/to/patch/
 ```
 * That's it! Now you can start your WildFly and try out new Weld.
 
-### What's the difference between `@ApplicationScoped` and `@Singleton`?
+</div></div></div>
+
+  <div class="accordion-item">
+    <h3 class="accordion-header">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#faq14" aria-expanded="false" aria-controls="faq14">
+        What's the difference between <code>@ApplicationScoped</code> and <code>@Singleton</code>?
+      </button>
+    </h3>
+    <div id="faq14" class="accordion-collapse collapse">
+      <div class="accordion-body">
 
 Both these contexts behave very similarly.
 A single bean instance is created and shared across the application.
@@ -398,3 +653,7 @@ Client proxies make it possible to [support circularities](https://docs.jboss.or
 There are also some use cases where it's desirable to destroy/recreate a bean instance via `Instance.destroy()` or `AlterableContext.destroy()`.
 With client proxy in place, all injection points operate on proxy objects that can lookup the contextual instance on demand therefore making it simple and safe to replace the contextual instance for a new one.
 On the other hand injecting a direct reference and attempting the same would lead to stale bean instances or working with outdated states of those instances.
+
+</div></div></div>
+
+</div>

--- a/public/css/weld-theme.css
+++ b/public/css/weld-theme.css
@@ -1326,3 +1326,175 @@ blockquote {
   display: table !important;
   clear: both !important;
 }
+
+/* ============================================
+   DOCUMENTATION PAGE - Card Grid & Accordion
+   ============================================ */
+
+/* Doc card sub-group labels */
+.doc-card-group-label {
+  font-size: 0.6875rem !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.08em !important;
+  color: var(--weld-text-muted) !important;
+  font-weight: 600 !important;
+  margin-bottom: 0.5rem !important;
+  margin-top: 0.75rem !important;
+  display: block !important;
+}
+
+.doc-card-group-label:first-of-type {
+  margin-top: 0 !important;
+}
+
+/* Latest badge */
+.doc-badge-latest {
+  background-color: var(--weld-success) !important;
+  color: white !important;
+  padding: 0.125rem 0.5rem !important;
+  border-radius: 1rem !important;
+  font-size: 0.6875rem !important;
+  font-weight: 600 !important;
+  vertical-align: middle !important;
+  margin-left: 0.375rem !important;
+}
+
+/* Older releases link */
+.doc-older-releases-card {
+  text-align: center !important;
+  margin-top: 1rem !important;
+  margin-bottom: 2rem !important;
+}
+
+.doc-older-releases-card a {
+  color: var(--weld-primary) !important;
+  font-weight: 500 !important;
+  font-size: 0.9375rem !important;
+}
+
+/* Documentation accordion - spaced rounded cards */
+.doc-accordion .accordion-item {
+  border: 1px solid var(--weld-border) !important;
+  border-radius: 0.5rem !important;
+  margin-bottom: 0.75rem !important;
+  overflow: hidden !important;
+}
+
+.doc-accordion .accordion-button {
+  font-weight: 500 !important;
+  color: var(--weld-primary-dark) !important;
+  background-color: var(--weld-bg-light) !important;
+  font-size: 0.9375rem !important;
+  padding: 0.875rem 1.25rem !important;
+}
+
+.doc-accordion .accordion-button:not(.collapsed) {
+  background-color: var(--weld-bg-accent) !important;
+  color: var(--weld-primary-dark) !important;
+  box-shadow: none !important;
+}
+
+.doc-accordion .accordion-button:focus {
+  box-shadow: 0 0 0 0.2rem rgba(59, 109, 140, 0.25) !important;
+  border-color: var(--weld-primary) !important;
+}
+
+.doc-accordion .accordion-body {
+  font-size: 0.9375rem !important;
+  line-height: 1.7 !important;
+  color: var(--color-text) !important;
+}
+
+.doc-accordion .accordion-body h4 {
+  margin-top: 1.25rem !important;
+}
+
+.doc-accordion .accordion-body pre {
+  margin: 1rem 0 !important;
+}
+
+/* FAQ permalink icon */
+.faq-permalink {
+  position: absolute !important;
+  right: 2.5rem !important;
+  top: 50% !important;
+  transform: translateY(-50%) !important;
+  color: var(--weld-text-muted) !important;
+  font-size: 0.8rem !important;
+  opacity: 0 !important;
+  transition: opacity 0.15s ease, color 0.15s ease !important;
+  z-index: 10 !important;
+  padding: 0.25rem !important;
+  cursor: pointer !important;
+}
+
+.accordion-header:hover .faq-permalink,
+.accordion-item:has(.accordion-button:not(.collapsed)) .faq-permalink {
+  opacity: 1 !important;
+}
+
+.faq-permalink:hover {
+  color: var(--weld-primary) !important;
+  text-decoration: none !important;
+}
+
+.faq-permalink-copied,
+.faq-permalink-copied:hover {
+  opacity: 1 !important;
+  color: var(--weld-success) !important;
+}
+
+[data-bs-theme="dark"] .faq-permalink {
+  color: var(--weld-text-muted) !important;
+}
+
+[data-bs-theme="dark"] .faq-permalink:hover {
+  color: var(--weld-accent) !important;
+}
+
+[data-bs-theme="dark"] .faq-permalink-copied,
+[data-bs-theme="dark"] .faq-permalink-copied:hover {
+  color: var(--weld-success) !important;
+}
+
+/* Dark mode - doc cards */
+[data-bs-theme="dark"] .doc-card-group-label {
+  color: var(--weld-text-muted) !important;
+}
+
+[data-bs-theme="dark"] .doc-badge-latest {
+  background-color: var(--weld-success) !important;
+}
+
+[data-bs-theme="dark"] .doc-older-releases-card a {
+  color: var(--weld-accent) !important;
+}
+
+/* Dark mode - accordion */
+[data-bs-theme="dark"] .doc-accordion .accordion-item {
+  background-color: #161b22 !important;
+  border-color: var(--weld-border) !important;
+}
+
+[data-bs-theme="dark"] .doc-accordion .accordion-button {
+  background-color: #1a1f24 !important;
+  color: #e6edf3 !important;
+}
+
+[data-bs-theme="dark"] .doc-accordion .accordion-button:not(.collapsed) {
+  background-color: #242b32 !important;
+  color: #e6edf3 !important;
+  box-shadow: none !important;
+}
+
+[data-bs-theme="dark"] .doc-accordion .accordion-button::after {
+  filter: invert(1) !important;
+}
+
+[data-bs-theme="dark"] .doc-accordion .accordion-button:focus {
+  box-shadow: 0 0 0 0.2rem rgba(232, 166, 58, 0.25) !important;
+}
+
+[data-bs-theme="dark"] .doc-accordion .accordion-body {
+  color: #c9d1d9 !important;
+}

--- a/public/js/site.js
+++ b/public/js/site.js
@@ -157,6 +157,77 @@
 })();
 
 /**
+ * FAQ Deep Links
+ * Opens and scrolls to a specific FAQ accordion item when the URL contains a hash
+ * e.g. /documentation#faq3 will open and scroll to the third FAQ
+ * Also adds a permalink icon to each FAQ header for easy link sharing.
+ */
+(function() {
+  'use strict';
+
+  document.addEventListener('DOMContentLoaded', () => {
+    // Add permalink icons to each FAQ accordion header
+    const accordion = document.querySelector('.doc-accordion');
+    if (accordion) {
+      accordion.querySelectorAll('.accordion-item').forEach(item => {
+        const collapseEl = item.querySelector('.accordion-collapse');
+        if (!collapseEl || !collapseEl.id) return;
+
+        const header = item.querySelector('.accordion-header');
+        if (!header) return;
+
+        header.style.position = 'relative';
+
+        const link = document.createElement('a');
+        link.href = '#' + collapseEl.id;
+        link.className = 'faq-permalink';
+        link.title = 'Copy link to this FAQ';
+        link.innerHTML = '<i class="fas fa-link"></i>';
+        link.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const url = window.location.origin + window.location.pathname + '#' + collapseEl.id;
+          if (!navigator.clipboard) return;
+          navigator.clipboard.writeText(url).then(() => {
+            link.title = 'Copied!';
+            link.classList.add('faq-permalink-copied');
+            setTimeout(() => {
+              link.title = 'Copy link to this FAQ';
+              link.classList.remove('faq-permalink-copied');
+            }, 2000);
+          }).catch(() => {});
+        });
+        header.appendChild(link);
+      });
+    }
+
+    // Open and scroll to FAQ if URL has a hash
+    const hash = window.location.hash;
+    if (!hash) return;
+
+    let target;
+    try { target = document.querySelector(hash); } catch (e) { return; }
+    if (!target || !target.classList.contains('accordion-collapse')) return;
+
+    if (typeof bootstrap === 'undefined' || !bootstrap.Collapse) return;
+    const bsCollapse = new bootstrap.Collapse(target, { toggle: false });
+    bsCollapse.show();
+
+    const accordionItem = target.closest('.accordion-item');
+    target.addEventListener('shown.bs.collapse', () => {
+      const el = accordionItem || target;
+      const navbar = document.querySelector('#top_subnav_branding');
+      const navHeight = navbar ? navbar.offsetHeight : 0;
+      const projNav = document.querySelector('#proj_nav');
+      const projNavHeight = projNav ? projNav.offsetHeight : 0;
+      const offset = navHeight + projNavHeight + 16;
+      const y = el.getBoundingClientRect().top + window.scrollY - offset;
+      window.scrollTo({ top: y, behavior: 'smooth' });
+    }, { once: true });
+  });
+})();
+
+/**
  * Clickable News Cards
  * Makes entire news/blog cards clickable while maintaining link accessibility
  */


### PR DESCRIPTION
Fixes #108

- Card grid layout for reference docs with grouped Weld/CDI links
- Collapsible FAQ accordion with spaced rounded cards
- FAQ deep links with permalink copy-to-clipboard
- Dark mode support

FAQ content is deliberately untouched and will be reviewed as part of #109.